### PR TITLE
Rename and publish Helm chart

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
+# Ignore build and test binaries.
+bin/
+
+# Helm chart packages and archives
+*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+bin/*
+Dockerfile.cross
+
+# Helm chart packages and archives
+*.tgz
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Go workspace file
+go.work
+
+# Kubernetes Generated files - skip generated files, except for vendored files
+!vendor/**/zz_generated.*
+
+# editor and IDE paraphernalia
+.idea
+.vscode
+*.swp
+*.swo
+*~

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,48 @@
+version: "2"
+run:
+  timeout: 5m
+  allow-parallel-runners: true
+
+issues:
+  # don't skip warning about doc comments
+  # don't exclude the default set of lint
+  exclude-use-default: false
+  # restore some of the defaults
+  # (fill in the rest as needed)
+  exclude-rules:
+    - path: "api/*"
+      linters:
+        - lll
+    - path: "internal/*"
+      linters:
+        - dupl
+        - lll
+linters:
+  disable-all: true
+  enable:
+    - dupl
+    - errcheck
+    - copyloopvar
+    - ginkgolinter
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+
+linters-settings:
+  revive:
+    rules:
+      - name: comment-spacings

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,14 @@ docker-build: manifests generate fmt vet ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}:${TAG}
 
+.PHONY: helm-package
+helm-package: manifests
+	$(HELM) package ./chart
+
+.PHONY: helm-push
+helm-push: manifests
+	$(HELM) push ${CHART} oci://ghcr.io/wal-g
+
 # PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
 # - be able to use docker buildx. More info: https://docs.docker.com/build/buildx/
@@ -172,6 +180,7 @@ $(LOCALBIN):
 ## Tool Binaries
 KUBECTL ?= kubectl
 KIND ?= kind
+HELM ?= helm
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: cnpg-plugin-wal-g
+name: cnpg-plugin-wal-g-chart
 description: A Helm chart for CloudnativePG WAL-G Plugin installation 
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
### Added:
- `.gitignore`: To exclude common development artifacts and build outputs.
- `.dockerignore`: To optimize Docker build context by excluding unnecessary files.
- `.golangci.yml`: Configuration file for `golangci-lint` to standardize linting across the codebase.

### Updated:
- Renamed the Helm chart to avoid naming collisions with the primary Docker image in the same OCI registry.

### Makefile Enhancements:
- Added `make` targets for building and publishing the Helm chart to the GHCR
