### PR TITLE
Bump RBAC role from config/rbac/role.yaml to chart/templates/rbac/role

### DIFF
--- a/chart/templates/rbac/role.yaml
+++ b/chart/templates/rbac/role.yaml
@@ -43,6 +43,40 @@ rules:
   - patch
   - update
 - apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - backups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - backups/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - backups/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings


### PR DESCRIPTION
This PR fixes non-working helm chart due to missing RBAC permissions on postgresql.cnpg.io resources