### PR TITLE
BackupConfig resource cleanup on deletion

### DIFF
--- a/api/v1beta1/backupconfig_types.go
+++ b/api/v1beta1/backupconfig_types.go
@@ -27,7 +27,7 @@ const BackupConfigFinalizerName = "cnpg-plugin-wal-g.yandex.cloud/backup-config-
 
 // Finalizer added to CNPG BackupConfig resources to protect Secrets from accidental deletion
 // It is used to ensure that Secrets are not deleted while they are still referenced by a BackupConfig
-const BackupConfigSecretProtectionFinalizerName = "cnpg-plugin-wal-g.yandex.cloud/secret-protection"
+const BackupConfigSecretFinalizerName = "cnpg-plugin-wal-g.yandex.cloud/used-by-backup-config"
 
 // S3StorageConfig defines S3-specific configuration for object storage
 type S3StorageConfig struct {

--- a/api/v1beta1/backupconfig_types.go
+++ b/api/v1beta1/backupconfig_types.go
@@ -25,6 +25,10 @@ import (
 // It is used to ensure that backup removed from storage before Backup resource deleted
 const BackupConfigFinalizerName = "cnpg-plugin-wal-g.yandex.cloud/backup-config-cleanup"
 
+// Finalizer added to CNPG BackupConfig resources to protect Secrets from accidental deletion
+// It is used to ensure that Secrets are not deleted while they are still referenced by a BackupConfig
+const BackupConfigSecretProtectionFinalizerName = "cnpg-plugin-wal-g.yandex.cloud/secret-protection"
+
 // S3StorageConfig defines S3-specific configuration for object storage
 type S3StorageConfig struct {
 	// e.g. s3://bucket/path/to/folder

--- a/api/v1beta1/backupconfig_types.go
+++ b/api/v1beta1/backupconfig_types.go
@@ -27,7 +27,7 @@ const BackupConfigFinalizerName = "cnpg-plugin-wal-g.yandex.cloud/backup-config-
 
 // Finalizer added to CNPG BackupConfig resources to protect Secrets from accidental deletion
 // It is used to ensure that Secrets are not deleted while they are still referenced by a BackupConfig
-const BackupConfigSecretFinalizerName = "cnpg-plugin-wal-g.yandex.cloud/used-by-backup-config"
+const BackupConfigSecretFinalizerName = "cnpg-plugin-wal-g.yandex.cloud/backup-config-secret-protection"
 
 // S3StorageConfig defines S3-specific configuration for object storage
 type S3StorageConfig struct {

--- a/chart/templates/rbac/role.yaml
+++ b/chart/templates/rbac/role.yaml
@@ -16,6 +16,7 @@ rules:
   - get
   - list
   - patch
+  - update
   - watch
 - apiGroups:
   - admissionregistration.k8s.io

--- a/config/crd/cnpg/postgresql.cnpg.io_backups.yaml
+++ b/config/crd/cnpg/postgresql.cnpg.io_backups.yaml
@@ -1,0 +1,445 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: backups.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    singular: backup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.method
+      name: Method
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.error
+      name: Error
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: A Backup resource is a request for a PostgreSQL backup by the
+          user.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired behavior of the backup.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              cluster:
+                description: The cluster to backup
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              method:
+                default: barmanObjectStore
+                description: |-
+                  The backup method to be used, possible options are `barmanObjectStore`,
+                  `volumeSnapshot` or `plugin`. Defaults to: `barmanObjectStore`.
+                enum:
+                - barmanObjectStore
+                - volumeSnapshot
+                - plugin
+                type: string
+              online:
+                description: |-
+                  Whether the default type of backup with volume snapshots is
+                  online/hot (`true`, default) or offline/cold (`false`)
+                  Overrides the default setting specified in the cluster field '.spec.backup.volumeSnapshot.online'
+                type: boolean
+              onlineConfiguration:
+                description: |-
+                  Configuration parameters to control the online/hot backup with volume snapshots
+                  Overrides the default settings specified in the cluster '.backup.volumeSnapshot.onlineConfiguration' stanza
+                properties:
+                  immediateCheckpoint:
+                    description: |-
+                      Control whether the I/O workload for the backup initial checkpoint will
+                      be limited, according to the `checkpoint_completion_target` setting on
+                      the PostgreSQL server. If set to true, an immediate checkpoint will be
+                      used, meaning PostgreSQL will complete the checkpoint as soon as
+                      possible. `false` by default.
+                    type: boolean
+                  waitForArchive:
+                    default: true
+                    description: |-
+                      If false, the function will return immediately after the backup is completed,
+                      without waiting for WAL to be archived.
+                      This behavior is only useful with backup software that independently monitors WAL archiving.
+                      Otherwise, WAL required to make the backup consistent might be missing and make the backup useless.
+                      By default, or when this parameter is true, pg_backup_stop will wait for WAL to be archived when archiving is
+                      enabled.
+                      On a standby, this means that it will wait only when archive_mode = always.
+                      If write activity on the primary is low, it may be useful to run pg_switch_wal on the primary in order to trigger
+                      an immediate segment switch.
+                    type: boolean
+                type: object
+              pluginConfiguration:
+                description: Configuration parameters passed to the plugin managing
+                  this backup
+                properties:
+                  name:
+                    description: Name is the name of the plugin managing this backup
+                    type: string
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Parameters are the configuration parameters passed to the backup
+                      plugin for this backup
+                    type: object
+                required:
+                - name
+                type: object
+              target:
+                description: |-
+                  The policy to decide which instance should perform this backup. If empty,
+                  it defaults to `cluster.spec.backup.target`.
+                  Available options are empty string, `primary` and `prefer-standby`.
+                  `primary` to have backups run always on primary instances,
+                  `prefer-standby` to have backups run preferably on the most updated
+                  standby, if available.
+                enum:
+                - primary
+                - prefer-standby
+                type: string
+            required:
+            - cluster
+            type: object
+            x-kubernetes-validations:
+            - message: BackupSpec is immutable once set
+              rule: oldSelf == self
+          status:
+            description: |-
+              Most recently observed status of the backup. This data may not be up to
+              date. Populated by the system. Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              azureCredentials:
+                description: The credentials to use to upload data to Azure Blob Storage
+                properties:
+                  connectionString:
+                    description: The connection string to be used
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  inheritFromAzureAD:
+                    description: Use the Azure AD based authentication without providing
+                      explicitly the keys.
+                    type: boolean
+                  storageAccount:
+                    description: The storage account where to upload data
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  storageKey:
+                    description: |-
+                      The storage account key to be used in conjunction
+                      with the storage account name
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  storageSasToken:
+                    description: |-
+                      A shared-access-signature to be used in conjunction with
+                      the storage account name
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                type: object
+              backupId:
+                description: The ID of the Barman backup
+                type: string
+              backupLabelFile:
+                description: Backup label file content as returned by Postgres in
+                  case of online (hot) backups
+                format: byte
+                type: string
+              backupName:
+                description: The Name of the Barman backup
+                type: string
+              beginLSN:
+                description: The starting xlog
+                type: string
+              beginWal:
+                description: The starting WAL
+                type: string
+              commandError:
+                description: The backup command output in case of error
+                type: string
+              commandOutput:
+                description: Unused. Retained for compatibility with old versions.
+                type: string
+              destinationPath:
+                description: |-
+                  The path where to store the backup (i.e. s3://bucket/path/to/folder)
+                  this path, with different destination folders, will be used for WALs
+                  and for data. This may not be populated in case of errors.
+                type: string
+              encryption:
+                description: Encryption method required to S3 API
+                type: string
+              endLSN:
+                description: The ending xlog
+                type: string
+              endWal:
+                description: The ending WAL
+                type: string
+              endpointCA:
+                description: |-
+                  EndpointCA store the CA bundle of the barman endpoint.
+                  Useful when using self-signed certificates to avoid
+                  errors with certificate issuer and barman-cloud-wal-archive.
+                properties:
+                  key:
+                    description: The key to select
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+              endpointURL:
+                description: |-
+                  Endpoint to be used to upload data to the cloud,
+                  overriding the automatic endpoint discovery
+                type: string
+              error:
+                description: The detected error
+                type: string
+              googleCredentials:
+                description: The credentials to use to upload data to Google Cloud
+                  Storage
+                properties:
+                  applicationCredentials:
+                    description: The secret containing the Google Cloud Storage JSON
+                      file with the credentials
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  gkeEnvironment:
+                    description: |-
+                      If set to true, will presume that it's running inside a GKE environment,
+                      default to false.
+                    type: boolean
+                type: object
+              instanceID:
+                description: Information to identify the instance where the backup
+                  has been taken from
+                properties:
+                  ContainerID:
+                    description: The container ID
+                    type: string
+                  podName:
+                    description: The pod name
+                    type: string
+                type: object
+              method:
+                description: The backup method being used
+                type: string
+              online:
+                description: Whether the backup was online/hot (`true`) or offline/cold
+                  (`false`)
+                type: boolean
+              phase:
+                description: The last backup status
+                type: string
+              pluginMetadata:
+                additionalProperties:
+                  type: string
+                description: A map containing the plugin metadata
+                type: object
+              s3Credentials:
+                description: The credentials to use to upload data to S3
+                properties:
+                  accessKeyId:
+                    description: The reference to the access key id
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  inheritFromIAMRole:
+                    description: Use the role based authentication without providing
+                      explicitly the keys.
+                    type: boolean
+                  region:
+                    description: The reference to the secret containing the region
+                      name
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  secretAccessKey:
+                    description: The reference to the secret access key
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  sessionToken:
+                    description: The references to the session key
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                type: object
+              serverName:
+                description: |-
+                  The server name on S3, the cluster name is used if this
+                  parameter is omitted
+                type: string
+              snapshotBackupStatus:
+                description: Status of the volumeSnapshot backup
+                properties:
+                  elements:
+                    description: The elements list, populated with the gathered volume
+                      snapshots
+                    items:
+                      description: BackupSnapshotElementStatus is a volume snapshot
+                        that is part of a volume snapshot method backup
+                      properties:
+                        name:
+                          description: Name is the snapshot resource name
+                          type: string
+                        tablespaceName:
+                          description: |-
+                            TablespaceName is the name of the snapshotted tablespace. Only set
+                            when type is PG_TABLESPACE
+                          type: string
+                        type:
+                          description: Type is tho role of the snapshot in the cluster,
+                            such as PG_DATA, PG_WAL and PG_TABLESPACE
+                          type: string
+                      required:
+                      - name
+                      - type
+                      type: object
+                    type: array
+                type: object
+              startedAt:
+                description: When the backup was started
+                format: date-time
+                type: string
+              stoppedAt:
+                description: When the backup was terminated
+                format: date-time
+                type: string
+              tablespaceMapFile:
+                description: Tablespace map file content as returned by Postgres in
+                  case of online (hot) backups
+                format: byte
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/cnpg/postgresql.cnpg.io_clusterimagecatalogs.yaml
+++ b/config/crd/cnpg/postgresql.cnpg.io_clusterimagecatalogs.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: clusterimagecatalogs.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: ClusterImageCatalog
+    listKind: ClusterImageCatalogList
+    plural: clusterimagecatalogs
+    singular: clusterimagecatalog
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterImageCatalog is the Schema for the clusterimagecatalogs
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired behavior of the ClusterImageCatalog.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              images:
+                description: List of CatalogImages available in the catalog
+                items:
+                  description: CatalogImage defines the image and major version
+                  properties:
+                    image:
+                      description: The image reference
+                      type: string
+                    major:
+                      description: The PostgreSQL major version of the image. Must
+                        be unique within the catalog.
+                      minimum: 10
+                      type: integer
+                  required:
+                  - image
+                  - major
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: Images must have unique major versions
+                  rule: self.all(e, self.filter(f, f.major==e.major).size() == 1)
+            required:
+            - images
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/crd/cnpg/postgresql.cnpg.io_clusters.yaml
+++ b/config/crd/cnpg/postgresql.cnpg.io_clusters.yaml
@@ -1,0 +1,6570 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: clusters.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Number of instances
+      jsonPath: .status.instances
+      name: Instances
+      type: integer
+    - description: Number of ready instances
+      jsonPath: .status.readyInstances
+      name: Ready
+      type: integer
+    - description: Cluster current status
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Primary pod
+      jsonPath: .status.currentPrimary
+      name: Primary
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the PostgreSQL API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired behavior of the cluster.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              affinity:
+                description: Affinity/Anti-affinity rules for Pods
+                properties:
+                  additionalPodAffinity:
+                    description: AdditionalPodAffinity allows to specify pod affinity
+                      terms to be passed to all the cluster's pods.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  additionalPodAntiAffinity:
+                    description: |-
+                      AdditionalPodAntiAffinity allows to specify pod anti-affinity terms to be added to the ones generated
+                      by the operator if EnablePodAntiAffinity is set to true (default) or to be used exclusively if set to false.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the anti-affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the anti-affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the anti-affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  enablePodAntiAffinity:
+                    description: |-
+                      Activates anti-affinity for the pods. The operator will define pods
+                      anti-affinity unless this field is explicitly set to false
+                    type: boolean
+                  nodeAffinity:
+                    description: |-
+                      NodeAffinity describes node affinity scheduling rules for the pod.
+                      More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: |-
+                            An empty preferred scheduling term matches all objects with implicit weight 0
+                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to an update), the system
+                          may or may not try to eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
+                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector is map of key-value pairs used to define the nodes on which
+                      the pods can run.
+                      More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                    type: object
+                  podAntiAffinityType:
+                    description: |-
+                      PodAntiAffinityType allows the user to decide whether pod anti-affinity between cluster instance has to be
+                      considered a strong requirement during scheduling or not. Allowed values are: "preferred" (default if empty) or
+                      "required". Setting it to "required", could lead to instances remaining pending until new kubernetes nodes are
+                      added if all the existing nodes don't match the required pod anti-affinity rule.
+                      More info:
+                      https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+                    type: string
+                  tolerations:
+                    description: |-
+                      Tolerations is a list of Tolerations that should be set for all the pods, in order to allow them to run
+                      on tainted nodes.
+                      More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologyKey:
+                    description: |-
+                      TopologyKey to use for anti-affinity configuration. See k8s documentation
+                      for more info on that
+                    type: string
+                type: object
+              backup:
+                description: The configuration to be used for backups
+                properties:
+                  barmanObjectStore:
+                    description: The configuration for the barman-cloud tool suite
+                    properties:
+                      azureCredentials:
+                        description: The credentials to use to upload data to Azure
+                          Blob Storage
+                        properties:
+                          connectionString:
+                            description: The connection string to be used
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          inheritFromAzureAD:
+                            description: Use the Azure AD based authentication without
+                              providing explicitly the keys.
+                            type: boolean
+                          storageAccount:
+                            description: The storage account where to upload data
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          storageKey:
+                            description: |-
+                              The storage account key to be used in conjunction
+                              with the storage account name
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          storageSasToken:
+                            description: |-
+                              A shared-access-signature to be used in conjunction with
+                              the storage account name
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
+                      data:
+                        description: |-
+                          The configuration to be used to backup the data files
+                          When not defined, base backups files will be stored uncompressed and may
+                          be unencrypted in the object store, according to the bucket default
+                          policy.
+                        properties:
+                          additionalCommandArgs:
+                            description: |-
+                              AdditionalCommandArgs represents additional arguments that can be appended
+                              to the 'barman-cloud-backup' command-line invocation. These arguments
+                              provide flexibility to customize the backup process further according to
+                              specific requirements or configurations.
+
+                              Example:
+                              In a scenario where specialized backup options are required, such as setting
+                              a specific timeout or defining custom behavior, users can use this field
+                              to specify additional command arguments.
+
+                              Note:
+                              It's essential to ensure that the provided arguments are valid and supported
+                              by the 'barman-cloud-backup' command, to avoid potential errors or unintended
+                              behavior during execution.
+                            items:
+                              type: string
+                            type: array
+                          compression:
+                            description: |-
+                              Compress a backup file (a tar file per tablespace) while streaming it
+                              to the object store. Available options are empty string (no
+                              compression, default), `gzip`, `bzip2`, and `snappy`.
+                            enum:
+                            - bzip2
+                            - gzip
+                            - snappy
+                            type: string
+                          encryption:
+                            description: |-
+                              Whenever to force the encryption of files (if the bucket is
+                              not already configured for that).
+                              Allowed options are empty string (use the bucket policy, default),
+                              `AES256` and `aws:kms`
+                            enum:
+                            - AES256
+                            - aws:kms
+                            type: string
+                          immediateCheckpoint:
+                            description: |-
+                              Control whether the I/O workload for the backup initial checkpoint will
+                              be limited, according to the `checkpoint_completion_target` setting on
+                              the PostgreSQL server. If set to true, an immediate checkpoint will be
+                              used, meaning PostgreSQL will complete the checkpoint as soon as
+                              possible. `false` by default.
+                            type: boolean
+                          jobs:
+                            description: |-
+                              The number of parallel jobs to be used to upload the backup, defaults
+                              to 2
+                            format: int32
+                            minimum: 1
+                            type: integer
+                        type: object
+                      destinationPath:
+                        description: |-
+                          The path where to store the backup (i.e. s3://bucket/path/to/folder)
+                          this path, with different destination folders, will be used for WALs
+                          and for data
+                        minLength: 1
+                        type: string
+                      endpointCA:
+                        description: |-
+                          EndpointCA store the CA bundle of the barman endpoint.
+                          Useful when using self-signed certificates to avoid
+                          errors with certificate issuer and barman-cloud-wal-archive
+                        properties:
+                          key:
+                            description: The key to select
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      endpointURL:
+                        description: |-
+                          Endpoint to be used to upload data to the cloud,
+                          overriding the automatic endpoint discovery
+                        type: string
+                      googleCredentials:
+                        description: The credentials to use to upload data to Google
+                          Cloud Storage
+                        properties:
+                          applicationCredentials:
+                            description: The secret containing the Google Cloud Storage
+                              JSON file with the credentials
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          gkeEnvironment:
+                            description: |-
+                              If set to true, will presume that it's running inside a GKE environment,
+                              default to false.
+                            type: boolean
+                        type: object
+                      historyTags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          HistoryTags is a list of key value pairs that will be passed to the
+                          Barman --history-tags option.
+                        type: object
+                      s3Credentials:
+                        description: The credentials to use to upload data to S3
+                        properties:
+                          accessKeyId:
+                            description: The reference to the access key id
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          inheritFromIAMRole:
+                            description: Use the role based authentication without
+                              providing explicitly the keys.
+                            type: boolean
+                          region:
+                            description: The reference to the secret containing the
+                              region name
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          secretAccessKey:
+                            description: The reference to the secret access key
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          sessionToken:
+                            description: The references to the session key
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
+                      serverName:
+                        description: |-
+                          The server name on S3, the cluster name is used if this
+                          parameter is omitted
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a list of key value pairs that will be passed to the
+                          Barman --tags option.
+                        type: object
+                      wal:
+                        description: |-
+                          The configuration for the backup of the WAL stream.
+                          When not defined, WAL files will be stored uncompressed and may be
+                          unencrypted in the object store, according to the bucket default policy.
+                        properties:
+                          archiveAdditionalCommandArgs:
+                            description: |-
+                              Additional arguments that can be appended to the 'barman-cloud-wal-archive'
+                              command-line invocation. These arguments provide flexibility to customize
+                              the WAL archive process further, according to specific requirements or configurations.
+
+                              Example:
+                              In a scenario where specialized backup options are required, such as setting
+                              a specific timeout or defining custom behavior, users can use this field
+                              to specify additional command arguments.
+
+                              Note:
+                              It's essential to ensure that the provided arguments are valid and supported
+                              by the 'barman-cloud-wal-archive' command, to avoid potential errors or unintended
+                              behavior during execution.
+                            items:
+                              type: string
+                            type: array
+                          compression:
+                            description: |-
+                              Compress a WAL file before sending it to the object store. Available
+                              options are empty string (no compression, default), `gzip`, `bzip2`,
+                              `lz4`, `snappy`, `xz`, and `zstd`.
+                            enum:
+                            - bzip2
+                            - gzip
+                            - lz4
+                            - snappy
+                            - xz
+                            - zstd
+                            type: string
+                          encryption:
+                            description: |-
+                              Whenever to force the encryption of files (if the bucket is
+                              not already configured for that).
+                              Allowed options are empty string (use the bucket policy, default),
+                              `AES256` and `aws:kms`
+                            enum:
+                            - AES256
+                            - aws:kms
+                            type: string
+                          maxParallel:
+                            description: |-
+                              Number of WAL files to be either archived in parallel (when the
+                              PostgreSQL instance is archiving to a backup object store) or
+                              restored in parallel (when a PostgreSQL standby is fetching WAL
+                              files from a recovery object store). If not specified, WAL files
+                              will be processed one at a time. It accepts a positive integer as a
+                              value - with 1 being the minimum accepted value.
+                            minimum: 1
+                            type: integer
+                          restoreAdditionalCommandArgs:
+                            description: |-
+                              Additional arguments that can be appended to the 'barman-cloud-wal-restore'
+                              command-line invocation. These arguments provide flexibility to customize
+                              the WAL restore process further, according to specific requirements or configurations.
+
+                              Example:
+                              In a scenario where specialized backup options are required, such as setting
+                              a specific timeout or defining custom behavior, users can use this field
+                              to specify additional command arguments.
+
+                              Note:
+                              It's essential to ensure that the provided arguments are valid and supported
+                              by the 'barman-cloud-wal-restore' command, to avoid potential errors or unintended
+                              behavior during execution.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    required:
+                    - destinationPath
+                    type: object
+                  retentionPolicy:
+                    description: |-
+                      RetentionPolicy is the retention policy to be used for backups
+                      and WALs (i.e. '60d'). The retention policy is expressed in the form
+                      of `XXu` where `XX` is a positive integer and `u` is in `[dwm]` -
+                      days, weeks, months.
+                      It's currently only applicable when using the BarmanObjectStore method.
+                    pattern: ^[1-9][0-9]*[dwm]$
+                    type: string
+                  target:
+                    default: prefer-standby
+                    description: |-
+                      The policy to decide which instance should perform backups. Available
+                      options are empty string, which will default to `prefer-standby` policy,
+                      `primary` to have backups run always on primary instances, `prefer-standby`
+                      to have backups run preferably on the most updated standby, if available.
+                    enum:
+                    - primary
+                    - prefer-standby
+                    type: string
+                  volumeSnapshot:
+                    description: VolumeSnapshot provides the configuration for the
+                      execution of volume snapshot backups.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations key-value pairs that will be added
+                          to .metadata.annotations snapshot resources.
+                        type: object
+                      className:
+                        description: |-
+                          ClassName specifies the Snapshot Class to be used for PG_DATA PersistentVolumeClaim.
+                          It is the default class for the other types if no specific class is present
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels are key-value pairs that will be added
+                          to .metadata.labels snapshot resources.
+                        type: object
+                      online:
+                        default: true
+                        description: |-
+                          Whether the default type of backup with volume snapshots is
+                          online/hot (`true`, default) or offline/cold (`false`)
+                        type: boolean
+                      onlineConfiguration:
+                        default:
+                          immediateCheckpoint: false
+                          waitForArchive: true
+                        description: Configuration parameters to control the online/hot
+                          backup with volume snapshots
+                        properties:
+                          immediateCheckpoint:
+                            description: |-
+                              Control whether the I/O workload for the backup initial checkpoint will
+                              be limited, according to the `checkpoint_completion_target` setting on
+                              the PostgreSQL server. If set to true, an immediate checkpoint will be
+                              used, meaning PostgreSQL will complete the checkpoint as soon as
+                              possible. `false` by default.
+                            type: boolean
+                          waitForArchive:
+                            default: true
+                            description: |-
+                              If false, the function will return immediately after the backup is completed,
+                              without waiting for WAL to be archived.
+                              This behavior is only useful with backup software that independently monitors WAL archiving.
+                              Otherwise, WAL required to make the backup consistent might be missing and make the backup useless.
+                              By default, or when this parameter is true, pg_backup_stop will wait for WAL to be archived when archiving is
+                              enabled.
+                              On a standby, this means that it will wait only when archive_mode = always.
+                              If write activity on the primary is low, it may be useful to run pg_switch_wal on the primary in order to trigger
+                              an immediate segment switch.
+                            type: boolean
+                        type: object
+                      snapshotOwnerReference:
+                        default: none
+                        description: SnapshotOwnerReference indicates the type of
+                          owner reference the snapshot should have
+                        enum:
+                        - none
+                        - cluster
+                        - backup
+                        type: string
+                      tablespaceClassName:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          TablespaceClassName specifies the Snapshot Class to be used for the tablespaces.
+                          defaults to the PGDATA Snapshot Class, if set
+                        type: object
+                      walClassName:
+                        description: WalClassName specifies the Snapshot Class to
+                          be used for the PG_WAL PersistentVolumeClaim.
+                        type: string
+                    type: object
+                type: object
+              bootstrap:
+                description: Instructions to bootstrap this cluster
+                properties:
+                  initdb:
+                    description: Bootstrap the cluster via initdb
+                    properties:
+                      builtinLocale:
+                        description: |-
+                          Specifies the locale name when the builtin provider is used.
+                          This option requires `localeProvider` to be set to `builtin`.
+                          Available from PostgreSQL 17.
+                        type: string
+                      dataChecksums:
+                        description: |-
+                          Whether the `-k` option should be passed to initdb,
+                          enabling checksums on data pages (default: `false`)
+                        type: boolean
+                      database:
+                        description: 'Name of the database used by the application.
+                          Default: `app`.'
+                        type: string
+                      encoding:
+                        description: The value to be passed as option `--encoding`
+                          for initdb (default:`UTF8`)
+                        type: string
+                      icuLocale:
+                        description: |-
+                          Specifies the ICU locale when the ICU provider is used.
+                          This option requires `localeProvider` to be set to `icu`.
+                          Available from PostgreSQL 15.
+                        type: string
+                      icuRules:
+                        description: |-
+                          Specifies additional collation rules to customize the behavior of the default collation.
+                          This option requires `localeProvider` to be set to `icu`.
+                          Available from PostgreSQL 16.
+                        type: string
+                      import:
+                        description: |-
+                          Bootstraps the new cluster by importing data from an existing PostgreSQL
+                          instance using logical backup (`pg_dump` and `pg_restore`)
+                        properties:
+                          databases:
+                            description: The databases to import
+                            items:
+                              type: string
+                            type: array
+                          pgDumpExtraOptions:
+                            description: |-
+                              List of custom options to pass to the `pg_dump` command. IMPORTANT:
+                              Use these options with caution and at your own risk, as the operator
+                              does not validate their content. Be aware that certain options may
+                              conflict with the operator's intended functionality or design.
+                            items:
+                              type: string
+                            type: array
+                          pgRestoreExtraOptions:
+                            description: |-
+                              List of custom options to pass to the `pg_restore` command. IMPORTANT:
+                              Use these options with caution and at your own risk, as the operator
+                              does not validate their content. Be aware that certain options may
+                              conflict with the operator's intended functionality or design.
+                            items:
+                              type: string
+                            type: array
+                          postImportApplicationSQL:
+                            description: |-
+                              List of SQL queries to be executed as a superuser in the application
+                              database right after is imported - to be used with extreme care
+                              (by default empty). Only available in microservice type.
+                            items:
+                              type: string
+                            type: array
+                          roles:
+                            description: The roles to import
+                            items:
+                              type: string
+                            type: array
+                          schemaOnly:
+                            description: |-
+                              When set to true, only the `pre-data` and `post-data` sections of
+                              `pg_restore` are invoked, avoiding data import. Default: `false`.
+                            type: boolean
+                          source:
+                            description: The source of the import
+                            properties:
+                              externalCluster:
+                                description: The name of the externalCluster used
+                                  for import
+                                type: string
+                            required:
+                            - externalCluster
+                            type: object
+                          type:
+                            description: The import type. Can be `microservice` or
+                              `monolith`.
+                            enum:
+                            - microservice
+                            - monolith
+                            type: string
+                        required:
+                        - databases
+                        - source
+                        - type
+                        type: object
+                      locale:
+                        description: Sets the default collation order and character
+                          classification in the new database.
+                        type: string
+                      localeCType:
+                        description: The value to be passed as option `--lc-ctype`
+                          for initdb (default:`C`)
+                        type: string
+                      localeCollate:
+                        description: The value to be passed as option `--lc-collate`
+                          for initdb (default:`C`)
+                        type: string
+                      localeProvider:
+                        description: |-
+                          This option sets the locale provider for databases created in the new cluster.
+                          Available from PostgreSQL 16.
+                        type: string
+                      options:
+                        description: |-
+                          The list of options that must be passed to initdb when creating the cluster.
+                          Deprecated: This could lead to inconsistent configurations,
+                          please use the explicit provided parameters instead.
+                          If defined, explicit values will be ignored.
+                        items:
+                          type: string
+                        type: array
+                      owner:
+                        description: |-
+                          Name of the owner of the database in the instance to be used
+                          by applications. Defaults to the value of the `database` key.
+                        type: string
+                      postInitApplicationSQL:
+                        description: |-
+                          List of SQL queries to be executed as a superuser in the application
+                          database right after the cluster has been created - to be used with extreme care
+                          (by default empty)
+                        items:
+                          type: string
+                        type: array
+                      postInitApplicationSQLRefs:
+                        description: |-
+                          List of references to ConfigMaps or Secrets containing SQL files
+                          to be executed as a superuser in the application database right after
+                          the cluster has been created. The references are processed in a specific order:
+                          first, all Secrets are processed, followed by all ConfigMaps.
+                          Within each group, the processing order follows the sequence specified
+                          in their respective arrays.
+                          (by default empty)
+                        properties:
+                          configMapRefs:
+                            description: ConfigMapRefs holds a list of references
+                              to ConfigMaps
+                            items:
+                              description: |-
+                                ConfigMapKeySelector contains enough information to let you locate
+                                the key of a ConfigMap
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            type: array
+                          secretRefs:
+                            description: SecretRefs holds a list of references to
+                              Secrets
+                            items:
+                              description: |-
+                                SecretKeySelector contains enough information to let you locate
+                                the key of a Secret
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      postInitSQL:
+                        description: |-
+                          List of SQL queries to be executed as a superuser in the `postgres`
+                          database right after the cluster has been created - to be used with extreme care
+                          (by default empty)
+                        items:
+                          type: string
+                        type: array
+                      postInitSQLRefs:
+                        description: |-
+                          List of references to ConfigMaps or Secrets containing SQL files
+                          to be executed as a superuser in the `postgres` database right after
+                          the cluster has been created. The references are processed in a specific order:
+                          first, all Secrets are processed, followed by all ConfigMaps.
+                          Within each group, the processing order follows the sequence specified
+                          in their respective arrays.
+                          (by default empty)
+                        properties:
+                          configMapRefs:
+                            description: ConfigMapRefs holds a list of references
+                              to ConfigMaps
+                            items:
+                              description: |-
+                                ConfigMapKeySelector contains enough information to let you locate
+                                the key of a ConfigMap
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            type: array
+                          secretRefs:
+                            description: SecretRefs holds a list of references to
+                              Secrets
+                            items:
+                              description: |-
+                                SecretKeySelector contains enough information to let you locate
+                                the key of a Secret
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      postInitTemplateSQL:
+                        description: |-
+                          List of SQL queries to be executed as a superuser in the `template1`
+                          database right after the cluster has been created - to be used with extreme care
+                          (by default empty)
+                        items:
+                          type: string
+                        type: array
+                      postInitTemplateSQLRefs:
+                        description: |-
+                          List of references to ConfigMaps or Secrets containing SQL files
+                          to be executed as a superuser in the `template1` database right after
+                          the cluster has been created. The references are processed in a specific order:
+                          first, all Secrets are processed, followed by all ConfigMaps.
+                          Within each group, the processing order follows the sequence specified
+                          in their respective arrays.
+                          (by default empty)
+                        properties:
+                          configMapRefs:
+                            description: ConfigMapRefs holds a list of references
+                              to ConfigMaps
+                            items:
+                              description: |-
+                                ConfigMapKeySelector contains enough information to let you locate
+                                the key of a ConfigMap
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            type: array
+                          secretRefs:
+                            description: SecretRefs holds a list of references to
+                              Secrets
+                            items:
+                              description: |-
+                                SecretKeySelector contains enough information to let you locate
+                                the key of a Secret
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      secret:
+                        description: |-
+                          Name of the secret containing the initial credentials for the
+                          owner of the user database. If empty a new secret will be
+                          created from scratch
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      walSegmentSize:
+                        description: |-
+                          The value in megabytes (1 to 1024) to be passed to the `--wal-segsize`
+                          option for initdb (default: empty, resulting in PostgreSQL default: 16MB)
+                        maximum: 1024
+                        minimum: 1
+                        type: integer
+                    type: object
+                    x-kubernetes-validations:
+                    - message: builtinLocale is only available when localeProvider
+                        is set to `builtin`
+                      rule: '!has(self.builtinLocale) || self.localeProvider == ''builtin'''
+                    - message: icuLocale is only available when localeProvider is
+                        set to `icu`
+                      rule: '!has(self.icuLocale) || self.localeProvider == ''icu'''
+                    - message: icuRules is only available when localeProvider is set
+                        to `icu`
+                      rule: '!has(self.icuRules) || self.localeProvider == ''icu'''
+                  pg_basebackup:
+                    description: |-
+                      Bootstrap the cluster taking a physical backup of another compatible
+                      PostgreSQL instance
+                    properties:
+                      database:
+                        description: 'Name of the database used by the application.
+                          Default: `app`.'
+                        type: string
+                      owner:
+                        description: |-
+                          Name of the owner of the database in the instance to be used
+                          by applications. Defaults to the value of the `database` key.
+                        type: string
+                      secret:
+                        description: |-
+                          Name of the secret containing the initial credentials for the
+                          owner of the user database. If empty a new secret will be
+                          created from scratch
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      source:
+                        description: The name of the server of which we need to take
+                          a physical backup
+                        minLength: 1
+                        type: string
+                    required:
+                    - source
+                    type: object
+                  recovery:
+                    description: Bootstrap the cluster from a backup
+                    properties:
+                      backup:
+                        description: |-
+                          The backup object containing the physical base backup from which to
+                          initiate the recovery procedure.
+                          Mutually exclusive with `source` and `volumeSnapshots`.
+                        properties:
+                          endpointCA:
+                            description: |-
+                              EndpointCA store the CA bundle of the barman endpoint.
+                              Useful when using self-signed certificates to avoid
+                              errors with certificate issuer and barman-cloud-wal-archive.
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      database:
+                        description: 'Name of the database used by the application.
+                          Default: `app`.'
+                        type: string
+                      owner:
+                        description: |-
+                          Name of the owner of the database in the instance to be used
+                          by applications. Defaults to the value of the `database` key.
+                        type: string
+                      recoveryTarget:
+                        description: |-
+                          By default, the recovery process applies all the available
+                          WAL files in the archive (full recovery). However, you can also
+                          end the recovery as soon as a consistent state is reached or
+                          recover to a point-in-time (PITR) by specifying a `RecoveryTarget` object,
+                          as expected by PostgreSQL (i.e., timestamp, transaction Id, LSN, ...).
+                          More info: https://www.postgresql.org/docs/current/runtime-config-wal.html#RUNTIME-CONFIG-WAL-RECOVERY-TARGET
+                        properties:
+                          backupID:
+                            description: |-
+                              The ID of the backup from which to start the recovery process.
+                              If empty (default) the operator will automatically detect the backup
+                              based on targetTime or targetLSN if specified. Otherwise use the
+                              latest available backup in chronological order.
+                            type: string
+                          exclusive:
+                            description: |-
+                              Set the target to be exclusive. If omitted, defaults to false, so that
+                              in Postgres, `recovery_target_inclusive` will be true
+                            type: boolean
+                          targetImmediate:
+                            description: End recovery as soon as a consistent state
+                              is reached
+                            type: boolean
+                          targetLSN:
+                            description: The target LSN (Log Sequence Number)
+                            type: string
+                          targetName:
+                            description: |-
+                              The target name (to be previously created
+                              with `pg_create_restore_point`)
+                            type: string
+                          targetTLI:
+                            description: The target timeline ("latest" or a positive
+                              integer)
+                            type: string
+                          targetTime:
+                            description: The target time as a timestamp in the RFC3339
+                              standard
+                            type: string
+                          targetXID:
+                            description: The target transaction ID
+                            type: string
+                        type: object
+                      secret:
+                        description: |-
+                          Name of the secret containing the initial credentials for the
+                          owner of the user database. If empty a new secret will be
+                          created from scratch
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      source:
+                        description: |-
+                          The external cluster whose backup we will restore. This is also
+                          used as the name of the folder under which the backup is stored,
+                          so it must be set to the name of the source cluster
+                          Mutually exclusive with `backup`.
+                        type: string
+                      volumeSnapshots:
+                        description: |-
+                          The static PVC data source(s) from which to initiate the
+                          recovery procedure. Currently supporting `VolumeSnapshot`
+                          and `PersistentVolumeClaim` resources that map an existing
+                          PVC group, compatible with CloudNativePG, and taken with
+                          a cold backup copy on a fenced Postgres instance (limitation
+                          which will be removed in the future when online backup
+                          will be implemented).
+                          Mutually exclusive with `backup`.
+                        properties:
+                          storage:
+                            description: Configuration of the storage of the instances
+                            properties:
+                              apiGroup:
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          tablespaceStorage:
+                            additionalProperties:
+                              description: |-
+                                TypedLocalObjectReference contains enough information to let you locate the
+                                typed referenced object inside the same namespace.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            description: Configuration of the storage for PostgreSQL
+                              tablespaces
+                            type: object
+                          walStorage:
+                            description: Configuration of the storage for PostgreSQL
+                              WAL (Write-Ahead Log)
+                            properties:
+                              apiGroup:
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                        - storage
+                        type: object
+                    type: object
+                type: object
+              certificates:
+                description: The configuration for the CA and related certificates
+                properties:
+                  clientCASecret:
+                    description: |-
+                      The secret containing the Client CA certificate. If not defined, a new secret will be created
+                      with a self-signed CA and will be used to generate all the client certificates.<br />
+                      <br />
+                      Contains:<br />
+                      <br />
+                      - `ca.crt`: CA that should be used to validate the client certificates,
+                      used as `ssl_ca_file` of all the instances.<br />
+                      - `ca.key`: key used to generate client certificates, if ReplicationTLSSecret is provided,
+                      this can be omitted.<br />
+                    type: string
+                  replicationTLSSecret:
+                    description: |-
+                      The secret of type kubernetes.io/tls containing the client certificate to authenticate as
+                      the `streaming_replica` user.
+                      If not defined, ClientCASecret must provide also `ca.key`, and a new secret will be
+                      created using the provided CA.
+                    type: string
+                  serverAltDNSNames:
+                    description: The list of the server alternative DNS names to be
+                      added to the generated server TLS certificates, when required.
+                    items:
+                      type: string
+                    type: array
+                  serverCASecret:
+                    description: |-
+                      The secret containing the Server CA certificate. If not defined, a new secret will be created
+                      with a self-signed CA and will be used to generate the TLS certificate ServerTLSSecret.<br />
+                      <br />
+                      Contains:<br />
+                      <br />
+                      - `ca.crt`: CA that should be used to validate the server certificate,
+                      used as `sslrootcert` in client connection strings.<br />
+                      - `ca.key`: key used to generate Server SSL certs, if ServerTLSSecret is provided,
+                      this can be omitted.<br />
+                    type: string
+                  serverTLSSecret:
+                    description: |-
+                      The secret of type kubernetes.io/tls containing the server TLS certificate and key that will be set as
+                      `ssl_cert_file` and `ssl_key_file` so that clients can connect to postgres securely.
+                      If not defined, ServerCASecret must provide also `ca.key` and a new secret will be
+                      created using the provided CA.
+                    type: string
+                type: object
+              description:
+                description: Description of this PostgreSQL cluster
+                type: string
+              enablePDB:
+                default: true
+                description: |-
+                  Manage the `PodDisruptionBudget` resources within the cluster. When
+                  configured as `true` (default setting), the pod disruption budgets
+                  will safeguard the primary node from being terminated. Conversely,
+                  setting it to `false` will result in the absence of any
+                  `PodDisruptionBudget` resource, permitting the shutdown of all nodes
+                  hosting the PostgreSQL cluster. This latter configuration is
+                  advisable for any PostgreSQL cluster employed for
+                  development/staging purposes.
+                type: boolean
+              enableSuperuserAccess:
+                default: false
+                description: |-
+                  When this option is enabled, the operator will use the `SuperuserSecret`
+                  to update the `postgres` user password (if the secret is
+                  not present, the operator will automatically create one). When this
+                  option is disabled, the operator will ignore the `SuperuserSecret` content, delete
+                  it when automatically created, and then blank the password of the `postgres`
+                  user by setting it to `NULL`. Disabled by default.
+                type: boolean
+              env:
+                description: |-
+                  Env follows the Env format to pass environment variables
+                  to the pods created in the cluster
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: |-
+                  EnvFrom follows the EnvFrom format to pass environment variables
+                  sources to the pods to be used by Env
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: Optional text to prepend to the name of each environment
+                        variable. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
+              ephemeralVolumeSource:
+                description: EphemeralVolumeSource allows the user to configure the
+                  source of ephemeral volumes.
+                properties:
+                  volumeClaimTemplate:
+                    description: |-
+                      Will be used to create a stand-alone PVC to provision the volume.
+                      The pod in which this EphemeralVolumeSource is embedded will be the
+                      owner of the PVC, i.e. the PVC will be deleted together with the
+                      pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                      `<volume name>` is the name from the `PodSpec.Volumes` array
+                      entry. Pod validation will reject the pod if the concatenated name
+                      is not valid for a PVC (for example, too long).
+
+                      An existing PVC with that name that is not owned by the pod
+                      will *not* be used for the pod to avoid using an unrelated
+                      volume by mistake. Starting the pod is then blocked until
+                      the unrelated PVC is removed. If such a pre-created PVC is
+                      meant to be used by the pod, the PVC has to updated with an
+                      owner reference to the pod once the pod exists. Normally
+                      this should not be necessary, but it may be useful when
+                      manually reconstructing a broken cluster.
+
+                      This field is read-only and no changes will be made by Kubernetes
+                      to the PVC after it has been created.
+
+                      Required, must not be nil.
+                    properties:
+                      metadata:
+                        description: |-
+                          May contain labels and annotations that will be copied into the PVC
+                          when creating it. No other fields are allowed and will be rejected during
+                          validation.
+                        type: object
+                      spec:
+                        description: |-
+                          The specification for the PersistentVolumeClaim. The entire content is
+                          copied unchanged into the PVC that gets created from this
+                          template. The same fields as in a PersistentVolumeClaim
+                          are also valid here.
+                        properties:
+                          accessModes:
+                            description: |-
+                              accessModes contains the desired access modes the volume should have.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          dataSource:
+                            description: |-
+                              dataSource field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                              * An existing PVC (PersistentVolumeClaim)
+                              If the provisioner or an external controller can support the specified data source,
+                              it will create a new volume based on the contents of the specified data source.
+                              When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                              and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                              If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                            properties:
+                              apiGroup:
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            description: |-
+                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                              volume is desired. This may be any object from a non-empty API group (non
+                              core object) or a PersistentVolumeClaim object.
+                              When this field is specified, volume binding will only succeed if the type of
+                              the specified object matches some installed volume populator or dynamic
+                              provisioner.
+                              This field will replace the functionality of the dataSource field and as such
+                              if both fields are non-empty, they must have the same value. For backwards
+                              compatibility, when namespace isn't specified in dataSourceRef,
+                              both fields (dataSource and dataSourceRef) will be set to the same
+                              value automatically if one of them is empty and the other is non-empty.
+                              When namespace is specified in dataSourceRef,
+                              dataSource isn't set to the same value and must be empty.
+                              There are three important differences between dataSource and dataSourceRef:
+                              * While dataSource only allows two specific types of objects, dataSourceRef
+                                allows any non-core object, as well as PersistentVolumeClaim objects.
+                              * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                preserves all values, and generates an error if a disallowed value is
+                                specified.
+                              * While dataSource only allows local objects, dataSourceRef allows objects
+                                in any namespaces.
+                              (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                              (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                            properties:
+                              apiGroup:
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace is the namespace of resource being referenced
+                                  Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                  (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            description: |-
+                              resources represents the minimum resources the volume should have.
+                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                              that are lower than previous value but must still be higher than capacity recorded in the
+                              status field of the claim.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          selector:
+                            description: selector is a label query over volumes to
+                              consider for binding.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            description: |-
+                              storageClassName is the name of the StorageClass required by the claim.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                            type: string
+                          volumeAttributesClassName:
+                            description: |-
+                              volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                              If specified, the CSI driver will create or update the volume with the attributes defined
+                              in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                              will be set by the persistentvolume controller if it exists.
+                              If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                              set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                              exists.
+                              More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                            type: string
+                          volumeMode:
+                            description: |-
+                              volumeMode defines what type of volume is required by the claim.
+                              Value of Filesystem is implied when not included in claim spec.
+                            type: string
+                          volumeName:
+                            description: volumeName is the binding reference to the
+                              PersistentVolume backing this claim.
+                            type: string
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                type: object
+              ephemeralVolumesSizeLimit:
+                description: |-
+                  EphemeralVolumesSizeLimit allows the user to set the limits for the ephemeral
+                  volumes
+                properties:
+                  shm:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Shm is the size limit of the shared memory volume
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  temporaryData:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: TemporaryData is the size limit of the temporary
+                      data volume
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              externalClusters:
+                description: The list of external clusters which are used in the configuration
+                items:
+                  description: |-
+                    ExternalCluster represents the connection parameters to an
+                    external cluster which is used in the other sections of the configuration
+                  properties:
+                    barmanObjectStore:
+                      description: The configuration for the barman-cloud tool suite
+                      properties:
+                        azureCredentials:
+                          description: The credentials to use to upload data to Azure
+                            Blob Storage
+                          properties:
+                            connectionString:
+                              description: The connection string to be used
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            inheritFromAzureAD:
+                              description: Use the Azure AD based authentication without
+                                providing explicitly the keys.
+                              type: boolean
+                            storageAccount:
+                              description: The storage account where to upload data
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            storageKey:
+                              description: |-
+                                The storage account key to be used in conjunction
+                                with the storage account name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            storageSasToken:
+                              description: |-
+                                A shared-access-signature to be used in conjunction with
+                                the storage account name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          type: object
+                        data:
+                          description: |-
+                            The configuration to be used to backup the data files
+                            When not defined, base backups files will be stored uncompressed and may
+                            be unencrypted in the object store, according to the bucket default
+                            policy.
+                          properties:
+                            additionalCommandArgs:
+                              description: |-
+                                AdditionalCommandArgs represents additional arguments that can be appended
+                                to the 'barman-cloud-backup' command-line invocation. These arguments
+                                provide flexibility to customize the backup process further according to
+                                specific requirements or configurations.
+
+                                Example:
+                                In a scenario where specialized backup options are required, such as setting
+                                a specific timeout or defining custom behavior, users can use this field
+                                to specify additional command arguments.
+
+                                Note:
+                                It's essential to ensure that the provided arguments are valid and supported
+                                by the 'barman-cloud-backup' command, to avoid potential errors or unintended
+                                behavior during execution.
+                              items:
+                                type: string
+                              type: array
+                            compression:
+                              description: |-
+                                Compress a backup file (a tar file per tablespace) while streaming it
+                                to the object store. Available options are empty string (no
+                                compression, default), `gzip`, `bzip2`, and `snappy`.
+                              enum:
+                              - bzip2
+                              - gzip
+                              - snappy
+                              type: string
+                            encryption:
+                              description: |-
+                                Whenever to force the encryption of files (if the bucket is
+                                not already configured for that).
+                                Allowed options are empty string (use the bucket policy, default),
+                                `AES256` and `aws:kms`
+                              enum:
+                              - AES256
+                              - aws:kms
+                              type: string
+                            immediateCheckpoint:
+                              description: |-
+                                Control whether the I/O workload for the backup initial checkpoint will
+                                be limited, according to the `checkpoint_completion_target` setting on
+                                the PostgreSQL server. If set to true, an immediate checkpoint will be
+                                used, meaning PostgreSQL will complete the checkpoint as soon as
+                                possible. `false` by default.
+                              type: boolean
+                            jobs:
+                              description: |-
+                                The number of parallel jobs to be used to upload the backup, defaults
+                                to 2
+                              format: int32
+                              minimum: 1
+                              type: integer
+                          type: object
+                        destinationPath:
+                          description: |-
+                            The path where to store the backup (i.e. s3://bucket/path/to/folder)
+                            this path, with different destination folders, will be used for WALs
+                            and for data
+                          minLength: 1
+                          type: string
+                        endpointCA:
+                          description: |-
+                            EndpointCA store the CA bundle of the barman endpoint.
+                            Useful when using self-signed certificates to avoid
+                            errors with certificate issuer and barman-cloud-wal-archive
+                          properties:
+                            key:
+                              description: The key to select
+                              type: string
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        endpointURL:
+                          description: |-
+                            Endpoint to be used to upload data to the cloud,
+                            overriding the automatic endpoint discovery
+                          type: string
+                        googleCredentials:
+                          description: The credentials to use to upload data to Google
+                            Cloud Storage
+                          properties:
+                            applicationCredentials:
+                              description: The secret containing the Google Cloud
+                                Storage JSON file with the credentials
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            gkeEnvironment:
+                              description: |-
+                                If set to true, will presume that it's running inside a GKE environment,
+                                default to false.
+                              type: boolean
+                          type: object
+                        historyTags:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            HistoryTags is a list of key value pairs that will be passed to the
+                            Barman --history-tags option.
+                          type: object
+                        s3Credentials:
+                          description: The credentials to use to upload data to S3
+                          properties:
+                            accessKeyId:
+                              description: The reference to the access key id
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            inheritFromIAMRole:
+                              description: Use the role based authentication without
+                                providing explicitly the keys.
+                              type: boolean
+                            region:
+                              description: The reference to the secret containing
+                                the region name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            secretAccessKey:
+                              description: The reference to the secret access key
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            sessionToken:
+                              description: The references to the session key
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          type: object
+                        serverName:
+                          description: |-
+                            The server name on S3, the cluster name is used if this
+                            parameter is omitted
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Tags is a list of key value pairs that will be passed to the
+                            Barman --tags option.
+                          type: object
+                        wal:
+                          description: |-
+                            The configuration for the backup of the WAL stream.
+                            When not defined, WAL files will be stored uncompressed and may be
+                            unencrypted in the object store, according to the bucket default policy.
+                          properties:
+                            archiveAdditionalCommandArgs:
+                              description: |-
+                                Additional arguments that can be appended to the 'barman-cloud-wal-archive'
+                                command-line invocation. These arguments provide flexibility to customize
+                                the WAL archive process further, according to specific requirements or configurations.
+
+                                Example:
+                                In a scenario where specialized backup options are required, such as setting
+                                a specific timeout or defining custom behavior, users can use this field
+                                to specify additional command arguments.
+
+                                Note:
+                                It's essential to ensure that the provided arguments are valid and supported
+                                by the 'barman-cloud-wal-archive' command, to avoid potential errors or unintended
+                                behavior during execution.
+                              items:
+                                type: string
+                              type: array
+                            compression:
+                              description: |-
+                                Compress a WAL file before sending it to the object store. Available
+                                options are empty string (no compression, default), `gzip`, `bzip2`,
+                                `lz4`, `snappy`, `xz`, and `zstd`.
+                              enum:
+                              - bzip2
+                              - gzip
+                              - lz4
+                              - snappy
+                              - xz
+                              - zstd
+                              type: string
+                            encryption:
+                              description: |-
+                                Whenever to force the encryption of files (if the bucket is
+                                not already configured for that).
+                                Allowed options are empty string (use the bucket policy, default),
+                                `AES256` and `aws:kms`
+                              enum:
+                              - AES256
+                              - aws:kms
+                              type: string
+                            maxParallel:
+                              description: |-
+                                Number of WAL files to be either archived in parallel (when the
+                                PostgreSQL instance is archiving to a backup object store) or
+                                restored in parallel (when a PostgreSQL standby is fetching WAL
+                                files from a recovery object store). If not specified, WAL files
+                                will be processed one at a time. It accepts a positive integer as a
+                                value - with 1 being the minimum accepted value.
+                              minimum: 1
+                              type: integer
+                            restoreAdditionalCommandArgs:
+                              description: |-
+                                Additional arguments that can be appended to the 'barman-cloud-wal-restore'
+                                command-line invocation. These arguments provide flexibility to customize
+                                the WAL restore process further, according to specific requirements or configurations.
+
+                                Example:
+                                In a scenario where specialized backup options are required, such as setting
+                                a specific timeout or defining custom behavior, users can use this field
+                                to specify additional command arguments.
+
+                                Note:
+                                It's essential to ensure that the provided arguments are valid and supported
+                                by the 'barman-cloud-wal-restore' command, to avoid potential errors or unintended
+                                behavior during execution.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      required:
+                      - destinationPath
+                      type: object
+                    connectionParameters:
+                      additionalProperties:
+                        type: string
+                      description: The list of connection parameters, such as dbname,
+                        host, username, etc
+                      type: object
+                    name:
+                      description: The server name, required
+                      type: string
+                    password:
+                      description: |-
+                        The reference to the password to be used to connect to the server.
+                        If a password is provided, CloudNativePG creates a PostgreSQL
+                        passfile at `/controller/external/NAME/pass` (where "NAME" is the
+                        cluster's name). This passfile is automatically referenced in the
+                        connection string when establishing a connection to the remote
+                        PostgreSQL server from the current PostgreSQL `Cluster`. This ensures
+                        secure and efficient password management for external clusters.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    plugin:
+                      description: |-
+                        The configuration of the plugin that is taking care
+                        of WAL archiving and backups for this external cluster
+                      properties:
+                        enabled:
+                          default: true
+                          description: Enabled is true if this plugin will be used
+                          type: boolean
+                        isWALArchiver:
+                          default: false
+                          description: |-
+                            Only one plugin can be declared as WALArchiver.
+                            Cannot be active if ".spec.backup.barmanObjectStore" configuration is present.
+                          type: boolean
+                        name:
+                          description: Name is the plugin name
+                          type: string
+                        parameters:
+                          additionalProperties:
+                            type: string
+                          description: Parameters is the configuration of the plugin
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    sslCert:
+                      description: |-
+                        The reference to an SSL certificate to be used to connect to this
+                        instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    sslKey:
+                      description: |-
+                        The reference to an SSL private key to be used to connect to this
+                        instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    sslRootCert:
+                      description: |-
+                        The reference to an SSL CA public key to be used to connect to this
+                        instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - name
+                  type: object
+                type: array
+              failoverDelay:
+                default: 0
+                description: |-
+                  The amount of time (in seconds) to wait before triggering a failover
+                  after the primary PostgreSQL instance in the cluster was detected
+                  to be unhealthy
+                format: int32
+                type: integer
+              imageCatalogRef:
+                description: Defines the major PostgreSQL version we want to use within
+                  an ImageCatalog
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  major:
+                    description: The major version of PostgreSQL we want to use from
+                      the ImageCatalog
+                    type: integer
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - major
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Only image catalogs are supported
+                  rule: self.kind == 'ImageCatalog' || self.kind == 'ClusterImageCatalog'
+                - message: Only image catalogs are supported
+                  rule: self.apiGroup == 'postgresql.cnpg.io'
+              imageName:
+                description: |-
+                  Name of the container image, supporting both tags (`<image>:<tag>`)
+                  and digests for deterministic and repeatable deployments
+                  (`<image>:<tag>@sha256:<digestValue>`)
+                type: string
+              imagePullPolicy:
+                description: |-
+                  Image pull policy.
+                  One of `Always`, `Never` or `IfNotPresent`.
+                  If not defined, it defaults to `IfNotPresent`.
+                  Cannot be updated.
+                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                type: string
+              imagePullSecrets:
+                description: The list of pull secrets to be used to pull the images
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate a
+                    local object with a known type inside the same namespace
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              inheritedMetadata:
+                description: Metadata that will be inherited by all objects related
+                  to the Cluster
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              instances:
+                default: 1
+                description: Number of instances required in the cluster
+                minimum: 1
+                type: integer
+              livenessProbeTimeout:
+                description: |-
+                  LivenessProbeTimeout is the time (in seconds) that is allowed for a PostgreSQL instance
+                  to successfully respond to the liveness probe (default 30).
+                  The Liveness probe failure threshold is derived from this value using the formula:
+                  ceiling(livenessProbe / 10).
+                format: int32
+                type: integer
+              logLevel:
+                default: info
+                description: 'The instances'' log level, one of the following values:
+                  error, warning, info (default), debug, trace'
+                enum:
+                - error
+                - warning
+                - info
+                - debug
+                - trace
+                type: string
+              managed:
+                description: The configuration that is used by the portions of PostgreSQL
+                  that are managed by the instance manager
+                properties:
+                  roles:
+                    description: Database roles managed by the `Cluster`
+                    items:
+                      description: |-
+                        RoleConfiguration is the representation, in Kubernetes, of a PostgreSQL role
+                        with the additional field Ensure specifying whether to ensure the presence or
+                        absence of the role in the database
+
+                        The defaults of the CREATE ROLE command are applied
+                        Reference: https://www.postgresql.org/docs/current/sql-createrole.html
+                      properties:
+                        bypassrls:
+                          description: |-
+                            Whether a role bypasses every row-level security (RLS) policy.
+                            Default is `false`.
+                          type: boolean
+                        comment:
+                          description: Description of the role
+                          type: string
+                        connectionLimit:
+                          default: -1
+                          description: |-
+                            If the role can log in, this specifies how many concurrent
+                            connections the role can make. `-1` (the default) means no limit.
+                          format: int64
+                          type: integer
+                        createdb:
+                          description: |-
+                            When set to `true`, the role being defined will be allowed to create
+                            new databases. Specifying `false` (default) will deny a role the
+                            ability to create databases.
+                          type: boolean
+                        createrole:
+                          description: |-
+                            Whether the role will be permitted to create, alter, drop, comment
+                            on, change the security label for, and grant or revoke membership in
+                            other roles. Default is `false`.
+                          type: boolean
+                        disablePassword:
+                          description: DisablePassword indicates that a role's password
+                            should be set to NULL in Postgres
+                          type: boolean
+                        ensure:
+                          default: present
+                          description: Ensure the role is `present` or `absent` -
+                            defaults to "present"
+                          enum:
+                          - present
+                          - absent
+                          type: string
+                        inRoles:
+                          description: |-
+                            List of one or more existing roles to which this role will be
+                            immediately added as a new member. Default empty.
+                          items:
+                            type: string
+                          type: array
+                        inherit:
+                          default: true
+                          description: |-
+                            Whether a role "inherits" the privileges of roles it is a member of.
+                            Defaults is `true`.
+                          type: boolean
+                        login:
+                          description: |-
+                            Whether the role is allowed to log in. A role having the `login`
+                            attribute can be thought of as a user. Roles without this attribute
+                            are useful for managing database privileges, but are not users in
+                            the usual sense of the word. Default is `false`.
+                          type: boolean
+                        name:
+                          description: Name of the role
+                          type: string
+                        passwordSecret:
+                          description: |-
+                            Secret containing the password of the role (if present)
+                            If null, the password will be ignored unless DisablePassword is set
+                          properties:
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        replication:
+                          description: |-
+                            Whether a role is a replication role. A role must have this
+                            attribute (or be a superuser) in order to be able to connect to the
+                            server in replication mode (physical or logical replication) and in
+                            order to be able to create or drop replication slots. A role having
+                            the `replication` attribute is a very highly privileged role, and
+                            should only be used on roles actually used for replication. Default
+                            is `false`.
+                          type: boolean
+                        superuser:
+                          description: |-
+                            Whether the role is a `superuser` who can override all access
+                            restrictions within the database - superuser status is dangerous and
+                            should be used only when really needed. You must yourself be a
+                            superuser to create a new superuser. Defaults is `false`.
+                          type: boolean
+                        validUntil:
+                          description: |-
+                            Date and time after which the role's password is no longer valid.
+                            When omitted, the password will never expire (default).
+                          format: date-time
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  services:
+                    description: Services roles managed by the `Cluster`
+                    properties:
+                      additional:
+                        description: Additional is a list of additional managed services
+                          specified by the user.
+                        items:
+                          description: |-
+                            ManagedService represents a specific service managed by the cluster.
+                            It includes the type of service and its associated template specification.
+                          properties:
+                            selectorType:
+                              description: |-
+                                SelectorType specifies the type of selectors that the service will have.
+                                Valid values are "rw", "r", and "ro", representing read-write, read, and read-only services.
+                              enum:
+                              - rw
+                              - r
+                              - ro
+                              type: string
+                            serviceTemplate:
+                              description: ServiceTemplate is the template specification
+                                for the service.
+                              properties:
+                                metadata:
+                                  description: |-
+                                    Standard object's metadata.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        Annotations is an unstructured key value map stored with a resource that may be
+                                        set by external tools to store and retrieve arbitrary metadata. They are not
+                                        queryable and should be preserved when modifying objects.
+                                        More info: http://kubernetes.io/docs/user-guide/annotations
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        Map of string keys and values that can be used to organize and categorize
+                                        (scope and select) objects. May match selectors of replication controllers
+                                        and services.
+                                        More info: http://kubernetes.io/docs/user-guide/labels
+                                      type: object
+                                    name:
+                                      description: The name of the resource. Only
+                                        supported for certain types
+                                      type: string
+                                  type: object
+                                spec:
+                                  description: |-
+                                    Specification of the desired behavior of the service.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                                  properties:
+                                    allocateLoadBalancerNodePorts:
+                                      description: |-
+                                        allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                        allocated for services with type LoadBalancer.  Default is "true". It
+                                        may be set to "false" if the cluster load-balancer does not rely on
+                                        NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                        value), those requests will be respected, regardless of this field.
+                                        This field may only be set for services with type LoadBalancer and will
+                                        be cleared if the type is changed to any other type.
+                                      type: boolean
+                                    clusterIP:
+                                      description: |-
+                                        clusterIP is the IP address of the service and is usually assigned
+                                        randomly. If an address is specified manually, is in-range (as per
+                                        system configuration), and is not in use, it will be allocated to the
+                                        service; otherwise creation of the service will fail. This field may not
+                                        be changed through updates unless the type field is also being changed
+                                        to ExternalName (which requires this field to be blank) or the type
+                                        field is being changed from ExternalName (in which case this field may
+                                        optionally be specified, as describe above).  Valid values are "None",
+                                        empty string (""), or a valid IP address. Setting this to "None" makes a
+                                        "headless service" (no virtual IP), which is useful when direct endpoint
+                                        connections are preferred and proxying is not required.  Only applies to
+                                        types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                        when creating a Service of type ExternalName, creation will fail. This
+                                        field will be wiped when updating a Service to type ExternalName.
+                                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                      type: string
+                                    clusterIPs:
+                                      description: |-
+                                        ClusterIPs is a list of IP addresses assigned to this service, and are
+                                        usually assigned randomly.  If an address is specified manually, is
+                                        in-range (as per system configuration), and is not in use, it will be
+                                        allocated to the service; otherwise creation of the service will fail.
+                                        This field may not be changed through updates unless the type field is
+                                        also being changed to ExternalName (which requires this field to be
+                                        empty) or the type field is being changed from ExternalName (in which
+                                        case this field may optionally be specified, as describe above).  Valid
+                                        values are "None", empty string (""), or a valid IP address.  Setting
+                                        this to "None" makes a "headless service" (no virtual IP), which is
+                                        useful when direct endpoint connections are preferred and proxying is
+                                        not required.  Only applies to types ClusterIP, NodePort, and
+                                        LoadBalancer. If this field is specified when creating a Service of type
+                                        ExternalName, creation will fail. This field will be wiped when updating
+                                        a Service to type ExternalName.  If this field is not specified, it will
+                                        be initialized from the clusterIP field.  If this field is specified,
+                                        clients must ensure that clusterIPs[0] and clusterIP have the same
+                                        value.
+
+                                        This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                        These IPs must correspond to the values of the ipFamilies field. Both
+                                        clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    externalIPs:
+                                      description: |-
+                                        externalIPs is a list of IP addresses for which nodes in the cluster
+                                        will also accept traffic for this service.  These IPs are not managed by
+                                        Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                        at a node with this IP.  A common example is external load-balancers
+                                        that are not part of the Kubernetes system.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    externalName:
+                                      description: |-
+                                        externalName is the external reference that discovery mechanisms will
+                                        return as an alias for this service (e.g. a DNS CNAME record). No
+                                        proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                        (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                                      type: string
+                                    externalTrafficPolicy:
+                                      description: |-
+                                        externalTrafficPolicy describes how nodes distribute service traffic they
+                                        receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                        ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                        the service in a way that assumes that external load balancers will take care
+                                        of balancing the service traffic between nodes, and so each node will deliver
+                                        traffic only to the node-local endpoints of the service, without masquerading
+                                        the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                        be dropped.) The default value, "Cluster", uses the standard behavior of
+                                        routing to all endpoints evenly (possibly modified by topology and other
+                                        features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                        within the cluster will always get "Cluster" semantics, but clients sending to
+                                        a NodePort from within the cluster may need to take traffic policy into account
+                                        when picking a node.
+                                      type: string
+                                    healthCheckNodePort:
+                                      description: |-
+                                        healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                        This only applies when type is set to LoadBalancer and
+                                        externalTrafficPolicy is set to Local. If a value is specified, is
+                                        in-range, and is not in use, it will be used.  If not specified, a value
+                                        will be automatically allocated.  External systems (e.g. load-balancers)
+                                        can use this port to determine if a given node holds endpoints for this
+                                        service or not.  If this field is specified when creating a Service
+                                        which does not need it, creation will fail. This field will be wiped
+                                        when updating a Service to no longer need it (e.g. changing type).
+                                        This field cannot be updated once set.
+                                      format: int32
+                                      type: integer
+                                    internalTrafficPolicy:
+                                      description: |-
+                                        InternalTrafficPolicy describes how nodes distribute service traffic they
+                                        receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                        only want to talk to endpoints of the service on the same node as the pod,
+                                        dropping the traffic if there are no local endpoints. The default value,
+                                        "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                        (possibly modified by topology and other features).
+                                      type: string
+                                    ipFamilies:
+                                      description: |-
+                                        IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                        service. This field is usually assigned automatically based on cluster
+                                        configuration and the ipFamilyPolicy field. If this field is specified
+                                        manually, the requested family is available in the cluster,
+                                        and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                        the service will fail. This field is conditionally mutable: it allows
+                                        for adding or removing a secondary IP family, but it does not allow
+                                        changing the primary IP family of the Service. Valid values are "IPv4"
+                                        and "IPv6".  This field only applies to Services of types ClusterIP,
+                                        NodePort, and LoadBalancer, and does apply to "headless" services.
+                                        This field will be wiped when updating a Service to type ExternalName.
+
+                                        This field may hold a maximum of two entries (dual-stack families, in
+                                        either order).  These families must correspond to the values of the
+                                        clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                        governed by the ipFamilyPolicy field.
+                                      items:
+                                        description: |-
+                                          IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                          to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    ipFamilyPolicy:
+                                      description: |-
+                                        IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                        this Service. If there is no value provided, then this field will be set
+                                        to SingleStack. Services can be "SingleStack" (a single IP family),
+                                        "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                        a single IP family on single-stack clusters), or "RequireDualStack"
+                                        (two IP families on dual-stack configured clusters, otherwise fail). The
+                                        ipFamilies and clusterIPs fields depend on the value of this field. This
+                                        field will be wiped when updating a service to type ExternalName.
+                                      type: string
+                                    loadBalancerClass:
+                                      description: |-
+                                        loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                        If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                        e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                        This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                        balancer implementation is used, today this is typically done through the cloud provider integration,
+                                        but should apply for any default implementation. If set, it is assumed that a load balancer
+                                        implementation is watching for Services with a matching class. Any default load balancer
+                                        implementation (e.g. cloud providers) should ignore Services that set this field.
+                                        This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                        Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                                      type: string
+                                    loadBalancerIP:
+                                      description: |-
+                                        Only applies to Service Type: LoadBalancer.
+                                        This feature depends on whether the underlying cloud-provider supports specifying
+                                        the loadBalancerIP when a load balancer is created.
+                                        This field will be ignored if the cloud-provider does not support the feature.
+                                        Deprecated: This field was under-specified and its meaning varies across implementations.
+                                        Using it is non-portable and it may not support dual-stack.
+                                        Users are encouraged to use implementation-specific annotations when available.
+                                      type: string
+                                    loadBalancerSourceRanges:
+                                      description: |-
+                                        If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                        load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                        cloud-provider does not support the feature."
+                                        More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    ports:
+                                      description: |-
+                                        The list of ports that are exposed by this service.
+                                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                      items:
+                                        description: ServicePort contains information
+                                          on service's port.
+                                        properties:
+                                          appProtocol:
+                                            description: |-
+                                              The application protocol for this port.
+                                              This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                              This field follows standard Kubernetes label syntax.
+                                              Valid values are either:
+
+                                              * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                              RFC-6335 and https://www.iana.org/assignments/service-names).
+
+                                              * Kubernetes-defined prefixed names:
+                                                * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                                * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                                * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+                                              * Other protocols should use implementation-defined prefixed names such as
+                                              mycompany.com/my-custom-protocol.
+                                            type: string
+                                          name:
+                                            description: |-
+                                              The name of this port within the service. This must be a DNS_LABEL.
+                                              All ports within a ServiceSpec must have unique names. When considering
+                                              the endpoints for a Service, this must match the 'name' field in the
+                                              EndpointPort.
+                                              Optional if only one ServicePort is defined on this service.
+                                            type: string
+                                          nodePort:
+                                            description: |-
+                                              The port on each node on which this service is exposed when type is
+                                              NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                              specified, in-range, and not in use it will be used, otherwise the
+                                              operation will fail.  If not specified, a port will be allocated if this
+                                              Service requires one.  If this field is specified when creating a
+                                              Service which does not need it, creation will fail. This field will be
+                                              wiped when updating a Service to no longer need it (e.g. changing type
+                                              from NodePort to ClusterIP).
+                                              More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+                                            format: int32
+                                            type: integer
+                                          port:
+                                            description: The port that will be exposed
+                                              by this service.
+                                            format: int32
+                                            type: integer
+                                          protocol:
+                                            default: TCP
+                                            description: |-
+                                              The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                              Default is TCP.
+                                            type: string
+                                          targetPort:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Number or name of the port to access on the pods targeted by the service.
+                                              Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                              If this is a string, it will be looked up as a named port in the
+                                              target Pod's container ports. If this is not specified, the value
+                                              of the 'port' field is used (an identity map).
+                                              This field is ignored for services with clusterIP=None, and should be
+                                              omitted or set equal to the 'port' field.
+                                              More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - port
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    publishNotReadyAddresses:
+                                      description: |-
+                                        publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                        Service should disregard any indications of ready/not-ready.
+                                        The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                        propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                        The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                        Services interpret this to mean that all endpoints are considered "ready" even if the
+                                        Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                        through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                                      type: boolean
+                                    selector:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        Route service traffic to pods with label keys and values matching this
+                                        selector. If empty or not present, the service is assumed to have an
+                                        external process managing its endpoints, which Kubernetes will not
+                                        modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                        Ignored if type is ExternalName.
+                                        More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    sessionAffinity:
+                                      description: |-
+                                        Supports "ClientIP" and "None". Used to maintain session affinity.
+                                        Enable client IP based session affinity.
+                                        Must be ClientIP or None.
+                                        Defaults to None.
+                                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                      type: string
+                                    sessionAffinityConfig:
+                                      description: sessionAffinityConfig contains
+                                        the configurations of session affinity.
+                                      properties:
+                                        clientIP:
+                                          description: clientIP contains the configurations
+                                            of Client IP based session affinity.
+                                          properties:
+                                            timeoutSeconds:
+                                              description: |-
+                                                timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                                The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                                Default value is 10800(for 3 hours).
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    trafficDistribution:
+                                      description: |-
+                                        TrafficDistribution offers a way to express preferences for how traffic
+                                        is distributed to Service endpoints. Implementations can use this field
+                                        as a hint, but are not required to guarantee strict adherence. If the
+                                        field is not set, the implementation will apply its default routing
+                                        strategy. If set to "PreferClose", implementations should prioritize
+                                        endpoints that are in the same zone.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                        options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                        "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                        to endpoints. Endpoints are determined by the selector or if that is not
+                                        specified, by manual construction of an Endpoints object or
+                                        EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                        allocated and the endpoints are published as a set of endpoints rather
+                                        than a virtual IP.
+                                        "NodePort" builds on ClusterIP and allocates a port on every node which
+                                        routes to the same endpoints as the clusterIP.
+                                        "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                        (if supported in the current cloud) which routes to the same endpoints
+                                        as the clusterIP.
+                                        "ExternalName" aliases this service to the specified externalName.
+                                        Several other fields do not apply to ExternalName services.
+                                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                                      type: string
+                                  type: object
+                              type: object
+                            updateStrategy:
+                              default: patch
+                              description: UpdateStrategy describes how the service
+                                differences should be reconciled
+                              enum:
+                              - patch
+                              - replace
+                              type: string
+                          required:
+                          - selectorType
+                          - serviceTemplate
+                          type: object
+                        type: array
+                      disabledDefaultServices:
+                        description: |-
+                          DisabledDefaultServices is a list of service types that are disabled by default.
+                          Valid values are "r", and "ro", representing read, and read-only services.
+                        items:
+                          description: |-
+                            ServiceSelectorType describes a valid value for generating the service selectors.
+                            It indicates which type of service the selector applies to, such as read-write, read, or read-only
+                          enum:
+                          - rw
+                          - r
+                          - ro
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              maxSyncReplicas:
+                default: 0
+                description: |-
+                  The target value for the synchronous replication quorum, that can be
+                  decreased if the number of ready standbys is lower than this.
+                  Undefined or 0 disable synchronous replication.
+                minimum: 0
+                type: integer
+              minSyncReplicas:
+                default: 0
+                description: |-
+                  Minimum number of instances required in synchronous replication with the
+                  primary. Undefined or 0 allow writes to complete when no standby is
+                  available.
+                minimum: 0
+                type: integer
+              monitoring:
+                description: The configuration of the monitoring infrastructure of
+                  this cluster
+                properties:
+                  customQueriesConfigMap:
+                    description: The list of config maps containing the custom queries
+                    items:
+                      description: |-
+                        ConfigMapKeySelector contains enough information to let you locate
+                        the key of a ConfigMap
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type: array
+                  customQueriesSecret:
+                    description: The list of secrets containing the custom queries
+                    items:
+                      description: |-
+                        SecretKeySelector contains enough information to let you locate
+                        the key of a Secret
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type: array
+                  disableDefaultQueries:
+                    default: false
+                    description: |-
+                      Whether the default queries should be injected.
+                      Set it to `true` if you don't want to inject default queries into the cluster.
+                      Default: false.
+                    type: boolean
+                  enablePodMonitor:
+                    default: false
+                    description: Enable or disable the `PodMonitor`
+                    type: boolean
+                  podMonitorMetricRelabelings:
+                    description: The list of metric relabelings for the `PodMonitor`.
+                      Applied to samples before ingestion.
+                    items:
+                      description: |-
+                        RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                        scraped samples and remote write samples.
+
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                      properties:
+                        action:
+                          default: replace
+                          description: |-
+                            Action to perform based on the regex matching.
+
+                            `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                            `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                            Default: "Replace"
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: |-
+                            Modulus to take of the hash of the source label values.
+
+                            Only applicable when the action is `HashMod`.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched.
+                          type: string
+                        replacement:
+                          description: |-
+                            Replacement value against which a Replace action is performed if the
+                            regular expression matches.
+
+                            Regex capture groups are available.
+                          type: string
+                        separator:
+                          description: Separator is the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: |-
+                            The source labels select values from existing labels. Their content is
+                            concatenated using the configured Separator and matched against the
+                            configured regular expression.
+                          items:
+                            description: |-
+                              LabelName is a valid Prometheus label name which may only contain ASCII
+                              letters, numbers, as well as underscores.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: |-
+                            Label to which the resulting string is written in a replacement.
+
+                            It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                            `KeepEqual` and `DropEqual` actions.
+
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
+                  podMonitorRelabelings:
+                    description: The list of relabelings for the `PodMonitor`. Applied
+                      to samples before scraping.
+                    items:
+                      description: |-
+                        RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                        scraped samples and remote write samples.
+
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                      properties:
+                        action:
+                          default: replace
+                          description: |-
+                            Action to perform based on the regex matching.
+
+                            `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                            `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                            Default: "Replace"
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: |-
+                            Modulus to take of the hash of the source label values.
+
+                            Only applicable when the action is `HashMod`.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched.
+                          type: string
+                        replacement:
+                          description: |-
+                            Replacement value against which a Replace action is performed if the
+                            regular expression matches.
+
+                            Regex capture groups are available.
+                          type: string
+                        separator:
+                          description: Separator is the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: |-
+                            The source labels select values from existing labels. Their content is
+                            concatenated using the configured Separator and matched against the
+                            configured regular expression.
+                          items:
+                            description: |-
+                              LabelName is a valid Prometheus label name which may only contain ASCII
+                              letters, numbers, as well as underscores.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: |-
+                            Label to which the resulting string is written in a replacement.
+
+                            It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                            `KeepEqual` and `DropEqual` actions.
+
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
+                  tls:
+                    description: |-
+                      Configure TLS communication for the metrics endpoint.
+                      Changing tls.enabled option will force a rollout of all instances.
+                    properties:
+                      enabled:
+                        default: false
+                        description: |-
+                          Enable TLS for the monitoring endpoint.
+                          Changing this option will force a rollout of all instances.
+                        type: boolean
+                    type: object
+                type: object
+              nodeMaintenanceWindow:
+                description: Define a maintenance window for the Kubernetes nodes
+                properties:
+                  inProgress:
+                    default: false
+                    description: Is there a node maintenance activity in progress?
+                    type: boolean
+                  reusePVC:
+                    default: true
+                    description: |-
+                      Reuse the existing PVC (wait for the node to come
+                      up again) or not (recreate it elsewhere - when `instances` >1)
+                    type: boolean
+                type: object
+              plugins:
+                description: |-
+                  The plugins configuration, containing
+                  any plugin to be loaded with the corresponding configuration
+                items:
+                  description: |-
+                    PluginConfiguration specifies a plugin that need to be loaded for this
+                    cluster to be reconciled
+                  properties:
+                    enabled:
+                      default: true
+                      description: Enabled is true if this plugin will be used
+                      type: boolean
+                    isWALArchiver:
+                      default: false
+                      description: |-
+                        Only one plugin can be declared as WALArchiver.
+                        Cannot be active if ".spec.backup.barmanObjectStore" configuration is present.
+                      type: boolean
+                    name:
+                      description: Name is the plugin name
+                      type: string
+                    parameters:
+                      additionalProperties:
+                        type: string
+                      description: Parameters is the configuration of the plugin
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              postgresGID:
+                default: 26
+                description: The GID of the `postgres` user inside the image, defaults
+                  to `26`
+                format: int64
+                type: integer
+              postgresUID:
+                default: 26
+                description: The UID of the `postgres` user inside the image, defaults
+                  to `26`
+                format: int64
+                type: integer
+              postgresql:
+                description: Configuration of the PostgreSQL server
+                properties:
+                  enableAlterSystem:
+                    description: |-
+                      If this parameter is true, the user will be able to invoke `ALTER SYSTEM`
+                      on this CloudNativePG Cluster.
+                      This should only be used for debugging and troubleshooting.
+                      Defaults to false.
+                    type: boolean
+                  extensions:
+                    description: The configuration of the extensions to be added
+                    items:
+                      description: |-
+                        ExtensionConfiguration is the configuration used to add
+                        PostgreSQL extensions to the Cluster.
+                      properties:
+                        dynamic_library_path:
+                          description: |-
+                            The list of directories inside the image which should be added to dynamic_library_path.
+                            If not defined, defaults to "/lib".
+                          items:
+                            type: string
+                          type: array
+                        extension_control_path:
+                          description: |-
+                            The list of directories inside the image which should be added to extension_control_path.
+                            If not defined, defaults to "/share".
+                          items:
+                            type: string
+                          type: array
+                        image:
+                          description: The image containing the extension, required
+                          properties:
+                            pullPolicy:
+                              description: |-
+                                Policy for pulling OCI objects. Possible values are:
+                                Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                              type: string
+                            reference:
+                              description: |-
+                                Required: Image or artifact reference to be used.
+                                Behaves in the same way as pod.spec.containers[*].image.
+                                Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                          - message: An image reference is required
+                            rule: has(self.reference)
+                        ld_library_path:
+                          description: The list of directories inside the image which
+                            should be added to ld_library_path.
+                          items:
+                            type: string
+                          type: array
+                        name:
+                          description: The name of the extension, required
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - image
+                      - name
+                      type: object
+                    type: array
+                  ldap:
+                    description: Options to specify LDAP configuration
+                    properties:
+                      bindAsAuth:
+                        description: Bind as authentication configuration
+                        properties:
+                          prefix:
+                            description: Prefix for the bind authentication option
+                            type: string
+                          suffix:
+                            description: Suffix for the bind authentication option
+                            type: string
+                        type: object
+                      bindSearchAuth:
+                        description: Bind+Search authentication configuration
+                        properties:
+                          baseDN:
+                            description: Root DN to begin the user search
+                            type: string
+                          bindDN:
+                            description: DN of the user to bind to the directory
+                            type: string
+                          bindPassword:
+                            description: Secret with the password for the user to
+                              bind to the directory
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          searchAttribute:
+                            description: Attribute to match against the username
+                            type: string
+                          searchFilter:
+                            description: Search filter to use when doing the search+bind
+                              authentication
+                            type: string
+                        type: object
+                      port:
+                        description: LDAP server port
+                        type: integer
+                      scheme:
+                        description: LDAP schema to be used, possible options are
+                          `ldap` and `ldaps`
+                        enum:
+                        - ldap
+                        - ldaps
+                        type: string
+                      server:
+                        description: LDAP hostname or IP address
+                        type: string
+                      tls:
+                        description: Set to 'true' to enable LDAP over TLS. 'false'
+                          is default
+                        type: boolean
+                    type: object
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: PostgreSQL configuration options (postgresql.conf)
+                    type: object
+                  pg_hba:
+                    description: |-
+                      PostgreSQL Host Based Authentication rules (lines to be appended
+                      to the pg_hba.conf file)
+                    items:
+                      type: string
+                    type: array
+                  pg_ident:
+                    description: |-
+                      PostgreSQL User Name Maps rules (lines to be appended
+                      to the pg_ident.conf file)
+                    items:
+                      type: string
+                    type: array
+                  promotionTimeout:
+                    description: |-
+                      Specifies the maximum number of seconds to wait when promoting an instance to primary.
+                      Default value is 40000000, greater than one year in seconds,
+                      big enough to simulate an infinite timeout
+                    format: int32
+                    type: integer
+                  shared_preload_libraries:
+                    description: Lists of shared preload libraries to add to the default
+                      ones
+                    items:
+                      type: string
+                    type: array
+                  syncReplicaElectionConstraint:
+                    description: |-
+                      Requirements to be met by sync replicas. This will affect how the "synchronous_standby_names" parameter will be
+                      set up.
+                    properties:
+                      enabled:
+                        description: This flag enables the constraints for sync replicas
+                        type: boolean
+                      nodeLabelsAntiAffinity:
+                        description: A list of node labels values to extract and compare
+                          to evaluate if the pods reside in the same topology or not
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - enabled
+                    type: object
+                  synchronous:
+                    description: Configuration of the PostgreSQL synchronous replication
+                      feature
+                    properties:
+                      dataDurability:
+                        description: |-
+                          If set to "required", data durability is strictly enforced. Write operations
+                          with synchronous commit settings (`on`, `remote_write`, or `remote_apply`) will
+                          block if there are insufficient healthy replicas, ensuring data persistence.
+                          If set to "preferred", data durability is maintained when healthy replicas
+                          are available, but the required number of instances will adjust dynamically
+                          if replicas become unavailable. This setting relaxes strict durability enforcement
+                          to allow for operational continuity. This setting is only applicable if both
+                          `standbyNamesPre` and `standbyNamesPost` are unset (empty).
+                        enum:
+                        - required
+                        - preferred
+                        type: string
+                      maxStandbyNamesFromCluster:
+                        description: |-
+                          Specifies the maximum number of local cluster pods that can be
+                          automatically included in the `synchronous_standby_names` option in
+                          PostgreSQL.
+                        type: integer
+                      method:
+                        description: |-
+                          Method to select synchronous replication standbys from the listed
+                          servers, accepting 'any' (quorum-based synchronous replication) or
+                          'first' (priority-based synchronous replication) as values.
+                        enum:
+                        - any
+                        - first
+                        type: string
+                      number:
+                        description: |-
+                          Specifies the number of synchronous standby servers that
+                          transactions must wait for responses from.
+                        type: integer
+                        x-kubernetes-validations:
+                        - message: The number of synchronous replicas should be greater
+                            than zero
+                          rule: self > 0
+                      standbyNamesPost:
+                        description: |-
+                          A user-defined list of application names to be added to
+                          `synchronous_standby_names` after local cluster pods (the order is
+                          only useful for priority-based synchronous replication).
+                        items:
+                          type: string
+                        type: array
+                      standbyNamesPre:
+                        description: |-
+                          A user-defined list of application names to be added to
+                          `synchronous_standby_names` before local cluster pods (the order is
+                          only useful for priority-based synchronous replication).
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - method
+                    - number
+                    type: object
+                    x-kubernetes-validations:
+                    - message: dataDurability set to 'preferred' requires empty 'standbyNamesPre'
+                        and empty 'standbyNamesPost'
+                      rule: self.dataDurability!='preferred' || ((!has(self.standbyNamesPre)
+                        || self.standbyNamesPre.size()==0) && (!has(self.standbyNamesPost)
+                        || self.standbyNamesPost.size()==0))
+                type: object
+              primaryUpdateMethod:
+                default: restart
+                description: |-
+                  Method to follow to upgrade the primary server during a rolling
+                  update procedure, after all replicas have been successfully updated:
+                  it can be with a switchover (`switchover`) or in-place (`restart` - default)
+                enum:
+                - switchover
+                - restart
+                type: string
+              primaryUpdateStrategy:
+                default: unsupervised
+                description: |-
+                  Deployment strategy to follow to upgrade the primary server during a rolling
+                  update procedure, after all replicas have been successfully updated:
+                  it can be automated (`unsupervised` - default) or manual (`supervised`)
+                enum:
+                - unsupervised
+                - supervised
+                type: string
+              priorityClassName:
+                description: |-
+                  Name of the priority class which will be used in every generated Pod, if the PriorityClass
+                  specified does not exist, the pod will not be able to schedule.  Please refer to
+                  https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
+                  for more information
+                type: string
+              probes:
+                description: |-
+                  The configuration of the probes to be injected
+                  in the PostgreSQL Pods.
+                properties:
+                  liveness:
+                    description: The liveness probe configuration
+                    properties:
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      isolationCheck:
+                        description: |-
+                          Configure the feature that extends the liveness probe for a primary
+                          instance. In addition to the basic checks, this verifies whether the
+                          primary is isolated from the Kubernetes API server and from its
+                          replicas, ensuring that it can be safely shut down if network
+                          partition or API unavailability is detected. Enabled by default.
+                        properties:
+                          connectionTimeout:
+                            default: 1000
+                            description: Timeout in milliseconds for connections during
+                              the primary isolation check
+                            type: integer
+                          enabled:
+                            default: true
+                            description: Whether primary isolation checking is enabled
+                              for the liveness probe
+                            type: boolean
+                          requestTimeout:
+                            default: 1000
+                            description: Timeout in milliseconds for requests during
+                              the primary isolation check
+                            type: integer
+                        type: object
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  readiness:
+                    description: The readiness probe configuration
+                    properties:
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      maximumLag:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Lag limit. Used only for `streaming` strategy
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      type:
+                        description: The probe strategy
+                        enum:
+                        - pg_isready
+                        - streaming
+                        - query
+                        type: string
+                    type: object
+                  startup:
+                    description: The startup probe configuration
+                    properties:
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      maximumLag:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Lag limit. Used only for `streaming` strategy
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      type:
+                        description: The probe strategy
+                        enum:
+                        - pg_isready
+                        - streaming
+                        - query
+                        type: string
+                    type: object
+                type: object
+              projectedVolumeTemplate:
+                description: |-
+                  Template to be used to define projected volumes, projected volumes will be mounted
+                  under `/projected` base folder
+                properties:
+                  defaultMode:
+                    description: |-
+                      defaultMode are the mode bits used to set permissions on created files by default.
+                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                      Directories within the path are not affected by this setting.
+                      This might be in conflict with other options that affect the file
+                      mode, like fsGroup, and the result can be other mode bits set.
+                    format: int32
+                    type: integer
+                  sources:
+                    description: |-
+                      sources is the list of volume projections. Each entry in this list
+                      handles one source.
+                    items:
+                      description: |-
+                        Projection that may be projected along with other supported volume types.
+                        Exactly one of these fields must be set.
+                      properties:
+                        clusterTrustBundle:
+                          description: |-
+                            ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                            of ClusterTrustBundle objects in an auto-updating file.
+
+                            Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                            ClusterTrustBundle objects can either be selected by name, or by the
+                            combination of signer name and a label selector.
+
+                            Kubelet performs aggressive normalization of the PEM contents written
+                            into the pod filesystem.  Esoteric PEM features such as inter-block
+                            comments and block headers are stripped.  Certificates are deduplicated.
+                            The ordering of certificates within the file is arbitrary, and Kubelet
+                            may change the order over time.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                Select all ClusterTrustBundles that match this label selector.  Only has
+                                effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                interpreted as "match nothing".  If set but empty, interpreted as "match
+                                everything".
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            name:
+                              description: |-
+                                Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                with signerName and labelSelector.
+                              type: string
+                            optional:
+                              description: |-
+                                If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                aren't available.  If using name, then the named ClusterTrustBundle is
+                                allowed not to exist.  If using signerName, then the combination of
+                                signerName and labelSelector is allowed to match zero
+                                ClusterTrustBundles.
+                              type: boolean
+                            path:
+                              description: Relative path from the volume root to write
+                                the bundle.
+                              type: string
+                            signerName:
+                              description: |-
+                                Select all ClusterTrustBundles that match this signer name.
+                                Mutually-exclusive with name.  The contents of all selected
+                                ClusterTrustBundles will be unified and deduplicated.
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        configMap:
+                          description: configMap information about the configMap data
+                            to project
+                          properties:
+                            items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                ConfigMap will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        downwardAPI:
+                          description: downwardAPI information about the downwardAPI
+                            data to project
+                          properties:
+                            items:
+                              description: Items is a list of DownwardAPIVolume file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name, namespace
+                                      and uid are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  mode:
+                                    description: |-
+                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        secret:
+                          description: secret information about the secret data to
+                            project
+                          properties:
+                            items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                Secret will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the Secret,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its key must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        serviceAccountToken:
+                          description: serviceAccountToken is information about the
+                            serviceAccountToken data to project
+                          properties:
+                            audience:
+                              description: |-
+                                audience is the intended audience of the token. A recipient of a token
+                                must identify itself with an identifier specified in the audience of the
+                                token, and otherwise should reject the token. The audience defaults to the
+                                identifier of the apiserver.
+                              type: string
+                            expirationSeconds:
+                              description: |-
+                                expirationSeconds is the requested duration of validity of the service
+                                account token. As the token approaches expiration, the kubelet volume
+                                plugin will proactively rotate the service account token. The kubelet will
+                                start trying to rotate the token if the token is older than 80 percent of
+                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                and must be at least 10 minutes.
+                              format: int64
+                              type: integer
+                            path:
+                              description: |-
+                                path is the path relative to the mount point of the file to project the
+                                token into.
+                              type: string
+                          required:
+                          - path
+                          type: object
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+              replica:
+                description: Replica cluster configuration
+                properties:
+                  enabled:
+                    description: |-
+                      If replica mode is enabled, this cluster will be a replica of an
+                      existing cluster. Replica cluster can be created from a recovery
+                      object store or via streaming through pg_basebackup.
+                      Refer to the Replica clusters page of the documentation for more information.
+                    type: boolean
+                  minApplyDelay:
+                    description: |-
+                      When replica mode is enabled, this parameter allows you to replay
+                      transactions only when the system time is at least the configured
+                      time past the commit time. This provides an opportunity to correct
+                      data loss errors. Note that when this parameter is set, a promotion
+                      token cannot be used.
+                    type: string
+                  primary:
+                    description: |-
+                      Primary defines which Cluster is defined to be the primary in the distributed PostgreSQL cluster, based on the
+                      topology specified in externalClusters
+                    type: string
+                  promotionToken:
+                    description: |-
+                      A demotion token generated by an external cluster used to
+                      check if the promotion requirements are met.
+                    type: string
+                  self:
+                    description: |-
+                      Self defines the name of this cluster. It is used to determine if this is a primary
+                      or a replica cluster, comparing it with `primary`
+                    type: string
+                  source:
+                    description: The name of the external cluster which is the replication
+                      origin
+                    minLength: 1
+                    type: string
+                required:
+                - source
+                type: object
+              replicationSlots:
+                default:
+                  highAvailability:
+                    enabled: true
+                description: Replication slots management configuration
+                properties:
+                  highAvailability:
+                    default:
+                      enabled: true
+                    description: Replication slots for high availability configuration
+                    properties:
+                      enabled:
+                        default: true
+                        description: |-
+                          If enabled (default), the operator will automatically manage replication slots
+                          on the primary instance and use them in streaming replication
+                          connections with all the standby instances that are part of the HA
+                          cluster. If disabled, the operator will not take advantage
+                          of replication slots in streaming connections with the replicas.
+                          This feature also controls replication slots in replica cluster,
+                          from the designated primary to its cascading replicas.
+                        type: boolean
+                      slotPrefix:
+                        default: _cnpg_
+                        description: |-
+                          Prefix for replication slots managed by the operator for HA.
+                          It may only contain lower case letters, numbers, and the underscore character.
+                          This can only be set at creation time. By default set to `_cnpg_`.
+                        pattern: ^[0-9a-z_]*$
+                        type: string
+                      synchronizeLogicalDecoding:
+                        description: |-
+                          When enabled, the operator automatically manages synchronization of logical
+                          decoding (replication) slots across high-availability clusters.
+
+                          Requires one of the following conditions:
+                          - PostgreSQL version 17 or later
+                          - PostgreSQL version < 17 with pg_failover_slots extension enabled
+                        type: boolean
+                    type: object
+                  synchronizeReplicas:
+                    description: Configures the synchronization of the user defined
+                      physical replication slots
+                    properties:
+                      enabled:
+                        default: true
+                        description: When set to true, every replication slot that
+                          is on the primary is synchronized on each standby
+                        type: boolean
+                      excludePatterns:
+                        description: List of regular expression patterns to match
+                          the names of replication slots to be excluded (by default
+                          empty)
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - enabled
+                    type: object
+                  updateInterval:
+                    default: 30
+                    description: |-
+                      Standby will update the status of the local replication slots
+                      every `updateInterval` seconds (default 30).
+                    minimum: 1
+                    type: integer
+                type: object
+              resources:
+                description: |-
+                  Resources requirements of every generated Pod. Please refer to
+                  https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                  for more information.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              schedulerName:
+                description: |-
+                  If specified, the pod will be dispatched by specified Kubernetes
+                  scheduler. If not specified, the pod will be dispatched by the default
+                  scheduler. More info:
+                  https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+                type: string
+              seccompProfile:
+                description: |-
+                  The SeccompProfile applied to every Pod and Container.
+                  Defaults to: `RuntimeDefault`
+                properties:
+                  localhostProfile:
+                    description: |-
+                      localhostProfile indicates a profile defined in a file on the node should be used.
+                      The profile must be preconfigured on the node to work.
+                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                    type: string
+                  type:
+                    description: |-
+                      type indicates which kind of seccomp profile will be applied.
+                      Valid options are:
+
+                      Localhost - a profile defined in a file on the node should be used.
+                      RuntimeDefault - the container runtime default profile should be used.
+                      Unconfined - no profile should be applied.
+                    type: string
+                required:
+                - type
+                type: object
+              serviceAccountTemplate:
+                description: Configure the generation of the service account
+                properties:
+                  metadata:
+                    description: |-
+                      Metadata are the metadata to be used for the generated
+                      service account
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: The name of the resource. Only supported for
+                          certain types
+                        type: string
+                    type: object
+                required:
+                - metadata
+                type: object
+              smartShutdownTimeout:
+                default: 180
+                description: |-
+                  The time in seconds that controls the window of time reserved for the smart shutdown of Postgres to complete.
+                  Make sure you reserve enough time for the operator to request a fast shutdown of Postgres
+                  (that is: `stopDelay` - `smartShutdownTimeout`).
+                format: int32
+                type: integer
+              startDelay:
+                default: 3600
+                description: |-
+                  The time in seconds that is allowed for a PostgreSQL instance to
+                  successfully start up (default 3600).
+                  The startup probe failure threshold is derived from this value using the formula:
+                  ceiling(startDelay / 10).
+                format: int32
+                type: integer
+              stopDelay:
+                default: 1800
+                description: |-
+                  The time in seconds that is allowed for a PostgreSQL instance to
+                  gracefully shutdown (default 1800)
+                format: int32
+                type: integer
+              storage:
+                description: Configuration of the storage of the instances
+                properties:
+                  pvcTemplate:
+                    description: Template to be used to generate the Persistent Volume
+                      Claim
+                    properties:
+                      accessModes:
+                        description: |-
+                          accessModes contains the desired access modes the volume should have.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      dataSource:
+                        description: |-
+                          dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                          * An existing PVC (PersistentVolumeClaim)
+                          If the provisioner or an external controller can support the specified data source,
+                          it will create a new volume based on the contents of the specified data source.
+                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        description: |-
+                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                          volume is desired. This may be any object from a non-empty API group (non
+                          core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed if the type of
+                          the specified object matches some installed volume populator or dynamic
+                          provisioner.
+                          This field will replace the functionality of the dataSource field and as such
+                          if both fields are non-empty, they must have the same value. For backwards
+                          compatibility, when namespace isn't specified in dataSourceRef,
+                          both fields (dataSource and dataSourceRef) will be set to the same
+                          value automatically if one of them is empty and the other is non-empty.
+                          When namespace is specified in dataSourceRef,
+                          dataSource isn't set to the same value and must be empty.
+                          There are three important differences between dataSource and dataSourceRef:
+                          * While dataSource only allows two specific types of objects, dataSourceRef
+                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                            preserves all values, and generates an error if a disallowed value is
+                            specified.
+                          * While dataSource only allows local objects, dataSourceRef allows objects
+                            in any namespaces.
+                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of resource being referenced
+                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: |-
+                          resources represents the minimum resources the volume should have.
+                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                          that are lower than previous value but must still be higher than capacity recorded in the
+                          status field of the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      selector:
+                        description: selector is a label query over volumes to consider
+                          for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        description: |-
+                          storageClassName is the name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                        type: string
+                      volumeAttributesClassName:
+                        description: |-
+                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                          If specified, the CSI driver will create or update the volume with the attributes defined
+                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                          will be set by the persistentvolume controller if it exists.
+                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                          exists.
+                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                        type: string
+                      volumeMode:
+                        description: |-
+                          volumeMode defines what type of volume is required by the claim.
+                          Value of Filesystem is implied when not included in claim spec.
+                        type: string
+                      volumeName:
+                        description: volumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                  resizeInUseVolumes:
+                    default: true
+                    description: Resize existent PVCs, defaults to true
+                    type: boolean
+                  size:
+                    description: |-
+                      Size of the storage. Required if not already specified in the PVC template.
+                      Changes to this field are automatically reapplied to the created PVCs.
+                      Size cannot be decreased.
+                    type: string
+                  storageClass:
+                    description: |-
+                      StorageClass to use for PVCs. Applied after
+                      evaluating the PVC template, if available.
+                      If not specified, the generated PVCs will use the
+                      default storage class
+                    type: string
+                type: object
+              superuserSecret:
+                description: |-
+                  The secret containing the superuser password. If not defined a new
+                  secret will be created with a randomly generated password
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              switchoverDelay:
+                default: 3600
+                description: |-
+                  The time in seconds that is allowed for a primary PostgreSQL instance
+                  to gracefully shutdown during a switchover.
+                  Default value is 3600 seconds (1 hour).
+                format: int32
+                type: integer
+              tablespaces:
+                description: The tablespaces configuration
+                items:
+                  description: |-
+                    TablespaceConfiguration is the configuration of a tablespace, and includes
+                    the storage specification for the tablespace
+                  properties:
+                    name:
+                      description: The name of the tablespace
+                      type: string
+                    owner:
+                      description: Owner is the PostgreSQL user owning the tablespace
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    storage:
+                      description: The storage configuration for the tablespace
+                      properties:
+                        pvcTemplate:
+                          description: Template to be used to generate the Persistent
+                            Volume Claim
+                          properties:
+                            accessModes:
+                              description: |-
+                                accessModes contains the desired access modes the volume should have.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            dataSource:
+                              description: |-
+                                dataSource field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim)
+                                If the provisioner or an external controller can support the specified data source,
+                                it will create a new volume based on the contents of the specified data source.
+                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty API group (non
+                                core object) or a PersistentVolumeClaim object.
+                                When this field is specified, volume binding will only succeed if the type of
+                                the specified object matches some installed volume populator or dynamic
+                                provisioner.
+                                This field will replace the functionality of the dataSource field and as such
+                                if both fields are non-empty, they must have the same value. For backwards
+                                compatibility, when namespace isn't specified in dataSourceRef,
+                                both fields (dataSource and dataSourceRef) will be set to the same
+                                value automatically if one of them is empty and the other is non-empty.
+                                When namespace is specified in dataSourceRef,
+                                dataSource isn't set to the same value and must be empty.
+                                There are three important differences between dataSource and dataSourceRef:
+                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                  in any namespaces.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of resource being referenced
+                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: |-
+                                resources represents the minimum resources the volume should have.
+                                If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                that are lower than previous value but must still be higher than capacity recorded in the
+                                status field of the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes
+                                to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: |-
+                                storageClassName is the name of the StorageClass required by the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                              type: string
+                            volumeAttributesClassName:
+                              description: |-
+                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                will be set by the persistentvolume controller if it exists.
+                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                exists.
+                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                              type: string
+                            volumeMode:
+                              description: |-
+                                volumeMode defines what type of volume is required by the claim.
+                                Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                        resizeInUseVolumes:
+                          default: true
+                          description: Resize existent PVCs, defaults to true
+                          type: boolean
+                        size:
+                          description: |-
+                            Size of the storage. Required if not already specified in the PVC template.
+                            Changes to this field are automatically reapplied to the created PVCs.
+                            Size cannot be decreased.
+                          type: string
+                        storageClass:
+                          description: |-
+                            StorageClass to use for PVCs. Applied after
+                            evaluating the PVC template, if available.
+                            If not specified, the generated PVCs will use the
+                            default storage class
+                          type: string
+                      type: object
+                    temporary:
+                      default: false
+                      description: |-
+                        When set to true, the tablespace will be added as a `temp_tablespaces`
+                        entry in PostgreSQL, and will be available to automatically house temp
+                        database objects, or other temporary files. Please refer to PostgreSQL
+                        documentation for more information on the `temp_tablespaces` GUC.
+                      type: boolean
+                  required:
+                  - name
+                  - storage
+                  type: object
+                type: array
+              topologySpreadConstraints:
+                description: |-
+                  TopologySpreadConstraints specifies how to spread matching pods among the given topology.
+                  More info:
+                  https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+                items:
+                  description: TopologySpreadConstraint specifies how to spread matching
+                    pods among the given topology.
+                  properties:
+                    labelSelector:
+                      description: |-
+                        LabelSelector is used to find matching pods.
+                        Pods that match this label selector are counted to determine the number of pods
+                        in their corresponding topology domain.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    matchLabelKeys:
+                      description: |-
+                        MatchLabelKeys is a set of pod label keys to select the pods over which
+                        spreading will be calculated. The keys are used to lookup values from the
+                        incoming pod labels, those key-value labels are ANDed with labelSelector
+                        to select the group of existing pods over which spreading will be calculated
+                        for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                        MatchLabelKeys cannot be set when LabelSelector isn't set.
+                        Keys that don't exist in the incoming pod labels will
+                        be ignored. A null or empty list means only match against labelSelector.
+
+                        This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    maxSkew:
+                      description: |-
+                        MaxSkew describes the degree to which pods may be unevenly distributed.
+                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                        between the number of matching pods in the target topology and the global minimum.
+                        The global minimum is the minimum number of matching pods in an eligible domain
+                        or zero if the number of eligible domains is less than MinDomains.
+                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                        labelSelector spread as 2/2/1:
+                        In this case, the global minimum is 1.
+                        | zone1 | zone2 | zone3 |
+                        |  P P  |  P P  |   P   |
+                        - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                        scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                        violate MaxSkew(1).
+                        - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                        When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                        to topologies that satisfy it.
+                        It's a required field. Default value is 1 and 0 is not allowed.
+                      format: int32
+                      type: integer
+                    minDomains:
+                      description: |-
+                        MinDomains indicates a minimum number of eligible domains.
+                        When the number of eligible domains with matching topology keys is less than minDomains,
+                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                        And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                        this value has no effect on scheduling.
+                        As a result, when the number of eligible domains is less than minDomains,
+                        scheduler won't schedule more than maxSkew Pods to those domains.
+                        If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                        Valid values are integers greater than 0.
+                        When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                        For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                        labelSelector spread as 2/2/2:
+                        | zone1 | zone2 | zone3 |
+                        |  P P  |  P P  |  P P  |
+                        The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                        In this situation, new pod with the same labelSelector cannot be scheduled,
+                        because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                        it will violate MaxSkew.
+                      format: int32
+                      type: integer
+                    nodeAffinityPolicy:
+                      description: |-
+                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                        when calculating pod topology spread skew. Options are:
+                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                        If this value is nil, the behavior is equivalent to the Honor policy.
+                      type: string
+                    nodeTaintsPolicy:
+                      description: |-
+                        NodeTaintsPolicy indicates how we will treat node taints when calculating
+                        pod topology spread skew. Options are:
+                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                        has a toleration, are included.
+                        - Ignore: node taints are ignored. All nodes are included.
+
+                        If this value is nil, the behavior is equivalent to the Ignore policy.
+                      type: string
+                    topologyKey:
+                      description: |-
+                        TopologyKey is the key of node labels. Nodes that have a label with this key
+                        and identical values are considered to be in the same topology.
+                        We consider each <key, value> as a "bucket", and try to put balanced number
+                        of pods into each bucket.
+                        We define a domain as a particular instance of a topology.
+                        Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                        nodeAffinityPolicy and nodeTaintsPolicy.
+                        e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                        And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                        It's a required field.
+                      type: string
+                    whenUnsatisfiable:
+                      description: |-
+                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                        the spread constraint.
+                        - DoNotSchedule (default) tells the scheduler not to schedule it.
+                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                          but giving higher precedence to topologies that would help reduce the
+                          skew.
+                        A constraint is considered "Unsatisfiable" for an incoming pod
+                        if and only if every possible node assignment for that pod would violate
+                        "MaxSkew" on some topology.
+                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                        labelSelector spread as 3/1/1:
+                        | zone1 | zone2 | zone3 |
+                        | P P P |   P   |   P   |
+                        If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                        to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                        MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                        won't make it *more* imbalanced.
+                        It's a required field.
+                      type: string
+                  required:
+                  - maxSkew
+                  - topologyKey
+                  - whenUnsatisfiable
+                  type: object
+                type: array
+              walStorage:
+                description: Configuration of the storage for PostgreSQL WAL (Write-Ahead
+                  Log)
+                properties:
+                  pvcTemplate:
+                    description: Template to be used to generate the Persistent Volume
+                      Claim
+                    properties:
+                      accessModes:
+                        description: |-
+                          accessModes contains the desired access modes the volume should have.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      dataSource:
+                        description: |-
+                          dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                          * An existing PVC (PersistentVolumeClaim)
+                          If the provisioner or an external controller can support the specified data source,
+                          it will create a new volume based on the contents of the specified data source.
+                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        description: |-
+                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                          volume is desired. This may be any object from a non-empty API group (non
+                          core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed if the type of
+                          the specified object matches some installed volume populator or dynamic
+                          provisioner.
+                          This field will replace the functionality of the dataSource field and as such
+                          if both fields are non-empty, they must have the same value. For backwards
+                          compatibility, when namespace isn't specified in dataSourceRef,
+                          both fields (dataSource and dataSourceRef) will be set to the same
+                          value automatically if one of them is empty and the other is non-empty.
+                          When namespace is specified in dataSourceRef,
+                          dataSource isn't set to the same value and must be empty.
+                          There are three important differences between dataSource and dataSourceRef:
+                          * While dataSource only allows two specific types of objects, dataSourceRef
+                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                            preserves all values, and generates an error if a disallowed value is
+                            specified.
+                          * While dataSource only allows local objects, dataSourceRef allows objects
+                            in any namespaces.
+                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of resource being referenced
+                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: |-
+                          resources represents the minimum resources the volume should have.
+                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                          that are lower than previous value but must still be higher than capacity recorded in the
+                          status field of the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      selector:
+                        description: selector is a label query over volumes to consider
+                          for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        description: |-
+                          storageClassName is the name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                        type: string
+                      volumeAttributesClassName:
+                        description: |-
+                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                          If specified, the CSI driver will create or update the volume with the attributes defined
+                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                          will be set by the persistentvolume controller if it exists.
+                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                          exists.
+                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                        type: string
+                      volumeMode:
+                        description: |-
+                          volumeMode defines what type of volume is required by the claim.
+                          Value of Filesystem is implied when not included in claim spec.
+                        type: string
+                      volumeName:
+                        description: volumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                  resizeInUseVolumes:
+                    default: true
+                    description: Resize existent PVCs, defaults to true
+                    type: boolean
+                  size:
+                    description: |-
+                      Size of the storage. Required if not already specified in the PVC template.
+                      Changes to this field are automatically reapplied to the created PVCs.
+                      Size cannot be decreased.
+                    type: string
+                  storageClass:
+                    description: |-
+                      StorageClass to use for PVCs. Applied after
+                      evaluating the PVC template, if available.
+                      If not specified, the generated PVCs will use the
+                      default storage class
+                    type: string
+                type: object
+            required:
+            - instances
+            type: object
+            x-kubernetes-validations:
+            - message: imageName and imageCatalogRef are mutually exclusive
+              rule: '!(has(self.imageCatalogRef) && has(self.imageName))'
+          status:
+            description: |-
+              Most recently observed status of the cluster. This data may not be up
+              to date. Populated by the system. Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              availableArchitectures:
+                description: AvailableArchitectures reports the available architectures
+                  of a cluster
+                items:
+                  description: AvailableArchitecture represents the state of a cluster's
+                    architecture
+                  properties:
+                    goArch:
+                      description: GoArch is the name of the executable architecture
+                      type: string
+                    hash:
+                      description: Hash is the hash of the executable
+                      type: string
+                  required:
+                  - goArch
+                  - hash
+                  type: object
+                type: array
+              certificates:
+                description: The configuration for the CA and related certificates,
+                  initialized with defaults.
+                properties:
+                  clientCASecret:
+                    description: |-
+                      The secret containing the Client CA certificate. If not defined, a new secret will be created
+                      with a self-signed CA and will be used to generate all the client certificates.<br />
+                      <br />
+                      Contains:<br />
+                      <br />
+                      - `ca.crt`: CA that should be used to validate the client certificates,
+                      used as `ssl_ca_file` of all the instances.<br />
+                      - `ca.key`: key used to generate client certificates, if ReplicationTLSSecret is provided,
+                      this can be omitted.<br />
+                    type: string
+                  expirations:
+                    additionalProperties:
+                      type: string
+                    description: Expiration dates for all certificates.
+                    type: object
+                  replicationTLSSecret:
+                    description: |-
+                      The secret of type kubernetes.io/tls containing the client certificate to authenticate as
+                      the `streaming_replica` user.
+                      If not defined, ClientCASecret must provide also `ca.key`, and a new secret will be
+                      created using the provided CA.
+                    type: string
+                  serverAltDNSNames:
+                    description: The list of the server alternative DNS names to be
+                      added to the generated server TLS certificates, when required.
+                    items:
+                      type: string
+                    type: array
+                  serverCASecret:
+                    description: |-
+                      The secret containing the Server CA certificate. If not defined, a new secret will be created
+                      with a self-signed CA and will be used to generate the TLS certificate ServerTLSSecret.<br />
+                      <br />
+                      Contains:<br />
+                      <br />
+                      - `ca.crt`: CA that should be used to validate the server certificate,
+                      used as `sslrootcert` in client connection strings.<br />
+                      - `ca.key`: key used to generate Server SSL certs, if ServerTLSSecret is provided,
+                      this can be omitted.<br />
+                    type: string
+                  serverTLSSecret:
+                    description: |-
+                      The secret of type kubernetes.io/tls containing the server TLS certificate and key that will be set as
+                      `ssl_cert_file` and `ssl_key_file` so that clients can connect to postgres securely.
+                      If not defined, ServerCASecret must provide also `ca.key` and a new secret will be
+                      created using the provided CA.
+                    type: string
+                type: object
+              cloudNativePGCommitHash:
+                description: The commit hash number of which this operator running
+                type: string
+              cloudNativePGOperatorHash:
+                description: The hash of the binary of the operator
+                type: string
+              conditions:
+                description: Conditions for cluster object
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              configMapResourceVersion:
+                description: |-
+                  The list of resource versions of the configmaps,
+                  managed by the operator. Every change here is done in the
+                  interest of the instance manager, which will refresh the
+                  configmap data
+                properties:
+                  metrics:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      A map with the versions of all the config maps used to pass metrics.
+                      Map keys are the config map names, map values are the versions
+                    type: object
+                type: object
+              currentPrimary:
+                description: Current primary instance
+                type: string
+              currentPrimaryFailingSinceTimestamp:
+                description: |-
+                  The timestamp when the primary was detected to be unhealthy
+                  This field is reported when `.spec.failoverDelay` is populated or during online upgrades
+                type: string
+              currentPrimaryTimestamp:
+                description: The timestamp when the last actual promotion to primary
+                  has occurred
+                type: string
+              danglingPVC:
+                description: |-
+                  List of all the PVCs created by this cluster and still available
+                  which are not attached to a Pod
+                items:
+                  type: string
+                type: array
+              demotionToken:
+                description: |-
+                  DemotionToken is a JSON token containing the information
+                  from pg_controldata such as Database system identifier, Latest checkpoint's
+                  TimeLineID, Latest checkpoint's REDO location, Latest checkpoint's REDO
+                  WAL file, and Time of latest checkpoint
+                type: string
+              firstRecoverabilityPoint:
+                description: |-
+                  The first recoverability point, stored as a date in RFC3339 format.
+                  This field is calculated from the content of FirstRecoverabilityPointByMethod.
+
+                  Deprecated: the field is not set for backup plugins.
+                type: string
+              firstRecoverabilityPointByMethod:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                description: |-
+                  The first recoverability point, stored as a date in RFC3339 format, per backup method type.
+
+                  Deprecated: the field is not set for backup plugins.
+                type: object
+              healthyPVC:
+                description: List of all the PVCs not dangling nor initializing
+                items:
+                  type: string
+                type: array
+              image:
+                description: Image contains the image name used by the pods
+                type: string
+              initializingPVC:
+                description: List of all the PVCs that are being initialized by this
+                  cluster
+                items:
+                  type: string
+                type: array
+              instanceNames:
+                description: List of instance names in the cluster
+                items:
+                  type: string
+                type: array
+              instances:
+                description: The total number of PVC Groups detected in the cluster.
+                  It may differ from the number of existing instance pods.
+                type: integer
+              instancesReportedState:
+                additionalProperties:
+                  description: InstanceReportedState describes the last reported state
+                    of an instance during a reconciliation loop
+                  properties:
+                    ip:
+                      description: IP address of the instance
+                      type: string
+                    isPrimary:
+                      description: indicates if an instance is the primary one
+                      type: boolean
+                    timeLineID:
+                      description: indicates on which TimelineId the instance is
+                      type: integer
+                  required:
+                  - isPrimary
+                  type: object
+                description: The reported state of the instances during the last reconciliation
+                  loop
+                type: object
+              instancesStatus:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: InstancesStatus indicates in which status the instances
+                  are
+                type: object
+              jobCount:
+                description: How many Jobs have been created by this cluster
+                format: int32
+                type: integer
+              lastFailedBackup:
+                description: |-
+                  Last failed backup, stored as a date in RFC3339 format.
+
+                  Deprecated: the field is not set for backup plugins.
+                type: string
+              lastPromotionToken:
+                description: |-
+                  LastPromotionToken is the last verified promotion token that
+                  was used to promote a replica cluster
+                type: string
+              lastSuccessfulBackup:
+                description: |-
+                  Last successful backup, stored as a date in RFC3339 format.
+                  This field is calculated from the content of LastSuccessfulBackupByMethod.
+
+                  Deprecated: the field is not set for backup plugins.
+                type: string
+              lastSuccessfulBackupByMethod:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                description: |-
+                  Last successful backup, stored as a date in RFC3339 format, per backup method type.
+
+                  Deprecated: the field is not set for backup plugins.
+                type: object
+              latestGeneratedNode:
+                description: ID of the latest generated node (used to avoid node name
+                  clashing)
+                type: integer
+              managedRolesStatus:
+                description: ManagedRolesStatus reports the state of the managed roles
+                  in the cluster
+                properties:
+                  byStatus:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: ByStatus gives the list of roles in each state
+                    type: object
+                  cannotReconcile:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: |-
+                      CannotReconcile lists roles that cannot be reconciled in PostgreSQL,
+                      with an explanation of the cause
+                    type: object
+                  passwordStatus:
+                    additionalProperties:
+                      description: PasswordState represents the state of the password
+                        of a managed RoleConfiguration
+                      properties:
+                        resourceVersion:
+                          description: the resource version of the password secret
+                          type: string
+                        transactionID:
+                          description: the last transaction ID to affect the role
+                            definition in PostgreSQL
+                          format: int64
+                          type: integer
+                      type: object
+                    description: PasswordStatus gives the last transaction id and
+                      password secret version for each managed role
+                    type: object
+                type: object
+              onlineUpdateEnabled:
+                description: OnlineUpdateEnabled shows if the online upgrade is enabled
+                  inside the cluster
+                type: boolean
+              pgDataImageInfo:
+                description: PGDataImageInfo contains the details of the latest image
+                  that has run on the current data directory.
+                properties:
+                  image:
+                    description: Image is the image name
+                    type: string
+                  majorVersion:
+                    description: MajorVersion is the major version of the image
+                    type: integer
+                required:
+                - image
+                - majorVersion
+                type: object
+              phase:
+                description: Current phase of the cluster
+                type: string
+              phaseReason:
+                description: Reason for the current phase
+                type: string
+              pluginStatus:
+                description: PluginStatus is the status of the loaded plugins
+                items:
+                  description: PluginStatus is the status of a loaded plugin
+                  properties:
+                    backupCapabilities:
+                      description: |-
+                        BackupCapabilities are the list of capabilities of the
+                        plugin regarding the Backup management
+                      items:
+                        type: string
+                      type: array
+                    capabilities:
+                      description: |-
+                        Capabilities are the list of capabilities of the
+                        plugin
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: Name is the name of the plugin
+                      type: string
+                    operatorCapabilities:
+                      description: |-
+                        OperatorCapabilities are the list of capabilities of the
+                        plugin regarding the reconciler
+                      items:
+                        type: string
+                      type: array
+                    restoreJobHookCapabilities:
+                      description: |-
+                        RestoreJobHookCapabilities are the list of capabilities of the
+                        plugin regarding the RestoreJobHook management
+                      items:
+                        type: string
+                      type: array
+                    status:
+                      description: Status contain the status reported by the plugin
+                        through the SetStatusInCluster interface
+                      type: string
+                    version:
+                      description: |-
+                        Version is the version of the plugin loaded by the
+                        latest reconciliation loop
+                      type: string
+                    walCapabilities:
+                      description: |-
+                        WALCapabilities are the list of capabilities of the
+                        plugin regarding the WAL management
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+              poolerIntegrations:
+                description: The integration needed by poolers referencing the cluster
+                properties:
+                  pgBouncerIntegration:
+                    description: PgBouncerIntegrationStatus encapsulates the needed
+                      integration for the pgbouncer poolers referencing the cluster
+                    properties:
+                      secrets:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              pvcCount:
+                description: How many PVCs have been created by this cluster
+                format: int32
+                type: integer
+              readService:
+                description: Current list of read pods
+                type: string
+              readyInstances:
+                description: The total number of ready instances in the cluster. It
+                  is equal to the number of ready instance pods.
+                type: integer
+              resizingPVC:
+                description: List of all the PVCs that have ResizingPVC condition.
+                items:
+                  type: string
+                type: array
+              secretsResourceVersion:
+                description: |-
+                  The list of resource versions of the secrets
+                  managed by the operator. Every change here is done in the
+                  interest of the instance manager, which will refresh the
+                  secret data
+                properties:
+                  applicationSecretVersion:
+                    description: The resource version of the "app" user secret
+                    type: string
+                  barmanEndpointCA:
+                    description: The resource version of the Barman Endpoint CA if
+                      provided
+                    type: string
+                  caSecretVersion:
+                    description: Unused. Retained for compatibility with old versions.
+                    type: string
+                  clientCaSecretVersion:
+                    description: The resource version of the PostgreSQL client-side
+                      CA secret version
+                    type: string
+                  externalClusterSecretVersion:
+                    additionalProperties:
+                      type: string
+                    description: The resource versions of the external cluster secrets
+                    type: object
+                  managedRoleSecretVersion:
+                    additionalProperties:
+                      type: string
+                    description: The resource versions of the managed roles secrets
+                    type: object
+                  metrics:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      A map with the versions of all the secrets used to pass metrics.
+                      Map keys are the secret names, map values are the versions
+                    type: object
+                  replicationSecretVersion:
+                    description: The resource version of the "streaming_replica" user
+                      secret
+                    type: string
+                  serverCaSecretVersion:
+                    description: The resource version of the PostgreSQL server-side
+                      CA secret version
+                    type: string
+                  serverSecretVersion:
+                    description: The resource version of the PostgreSQL server-side
+                      secret version
+                    type: string
+                  superuserSecretVersion:
+                    description: The resource version of the "postgres" user secret
+                    type: string
+                type: object
+              switchReplicaClusterStatus:
+                description: SwitchReplicaClusterStatus is the status of the switch
+                  to replica cluster
+                properties:
+                  inProgress:
+                    description: InProgress indicates if there is an ongoing procedure
+                      of switching a cluster to a replica cluster.
+                    type: boolean
+                type: object
+              systemID:
+                description: SystemID is the latest detected PostgreSQL SystemID
+                type: string
+              tablespacesStatus:
+                description: TablespacesStatus reports the state of the declarative
+                  tablespaces in the cluster
+                items:
+                  description: TablespaceState represents the state of a tablespace
+                    in a cluster
+                  properties:
+                    error:
+                      description: Error is the reconciliation error, if any
+                      type: string
+                    name:
+                      description: Name is the name of the tablespace
+                      type: string
+                    owner:
+                      description: Owner is the PostgreSQL user owning the tablespace
+                      type: string
+                    state:
+                      description: State is the latest reconciliation state
+                      type: string
+                  required:
+                  - name
+                  - state
+                  type: object
+                type: array
+              targetPrimary:
+                description: |-
+                  Target primary instance, this is different from the previous one
+                  during a switchover or a failover
+                type: string
+              targetPrimaryTimestamp:
+                description: The timestamp when the last request for a new primary
+                  has occurred
+                type: string
+              timelineID:
+                description: The timeline of the Postgres cluster
+                type: integer
+              topology:
+                description: Instances topology.
+                properties:
+                  instances:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      description: PodTopologyLabels represent the topology of a Pod.
+                        map[labelName]labelValue
+                      type: object
+                    description: Instances contains the pod topology of the instances
+                    type: object
+                  nodesUsed:
+                    description: |-
+                      NodesUsed represents the count of distinct nodes accommodating the instances.
+                      A value of '1' suggests that all instances are hosted on a single node,
+                      implying the absence of High Availability (HA). Ideally, this value should
+                      be the same as the number of instances in the Postgres HA cluster, implying
+                      shared nothing architecture on the compute side.
+                    format: int32
+                    type: integer
+                  successfullyExtracted:
+                    description: |-
+                      SuccessfullyExtracted indicates if the topology data was extract. It is useful to enact fallback behaviors
+                      in synchronous replica election in case of failures
+                    type: boolean
+                type: object
+              unusablePVC:
+                description: List of all the PVCs that are unusable because another
+                  PVC is missing
+                items:
+                  type: string
+                type: array
+              writeService:
+                description: Current write pod
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.instances
+        statusReplicasPath: .status.instances
+      status: {}

--- a/config/crd/cnpg/postgresql.cnpg.io_databases.yaml
+++ b/config/crd/cnpg/postgresql.cnpg.io_databases.yaml
@@ -1,0 +1,372 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: databases.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Database
+    listKind: DatabaseList
+    plural: databases
+    singular: database
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.name
+      name: PG Name
+      type: string
+    - jsonPath: .status.applied
+      name: Applied
+      type: boolean
+    - description: Latest reconciliation message
+      jsonPath: .status.message
+      name: Message
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Database is the Schema for the databases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired Database.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              allowConnections:
+                description: |-
+                  Maps to the `ALLOW_CONNECTIONS` parameter of `CREATE DATABASE` and
+                  `ALTER DATABASE`. If false then no one can connect to this database.
+                type: boolean
+              builtinLocale:
+                description: |-
+                  Maps to the `BUILTIN_LOCALE` parameter of `CREATE DATABASE`. This
+                  setting cannot be changed. Specifies the locale name when the
+                  builtin provider is used. This option requires `localeProvider` to
+                  be set to `builtin`. Available from PostgreSQL 17.
+                type: string
+                x-kubernetes-validations:
+                - message: builtinLocale is immutable
+                  rule: self == oldSelf
+              cluster:
+                description: The name of the PostgreSQL cluster hosting the database.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              collationVersion:
+                description: |-
+                  Maps to the `COLLATION_VERSION` parameter of `CREATE DATABASE`. This
+                  setting cannot be changed.
+                type: string
+                x-kubernetes-validations:
+                - message: collationVersion is immutable
+                  rule: self == oldSelf
+              connectionLimit:
+                description: |-
+                  Maps to the `CONNECTION LIMIT` clause of `CREATE DATABASE` and
+                  `ALTER DATABASE`. How many concurrent connections can be made to
+                  this database. -1 (the default) means no limit.
+                type: integer
+              databaseReclaimPolicy:
+                default: retain
+                description: The policy for end-of-life maintenance of this database.
+                enum:
+                - delete
+                - retain
+                type: string
+              encoding:
+                description: |-
+                  Maps to the `ENCODING` parameter of `CREATE DATABASE`. This setting
+                  cannot be changed. Character set encoding to use in the database.
+                type: string
+                x-kubernetes-validations:
+                - message: encoding is immutable
+                  rule: self == oldSelf
+              ensure:
+                default: present
+                description: Ensure the PostgreSQL database is `present` or `absent`
+                  - defaults to "present".
+                enum:
+                - present
+                - absent
+                type: string
+              extensions:
+                description: The list of extensions to be managed in the database
+                items:
+                  description: ExtensionSpec configures an extension in a database
+                  properties:
+                    ensure:
+                      default: present
+                      description: |-
+                        Specifies whether an extension/schema should be present or absent in
+                        the database. If set to `present`, the extension/schema will be
+                        created if it does not exist. If set to `absent`, the
+                        extension/schema will be removed if it exists.
+                      enum:
+                      - present
+                      - absent
+                      type: string
+                    name:
+                      description: Name of the extension/schema
+                      type: string
+                    schema:
+                      description: |-
+                        The name of the schema in which to install the extension's objects,
+                        in case the extension allows its contents to be relocated. If not
+                        specified (default), and the extension's control file does not
+                        specify a schema either, the current default object creation schema
+                        is used.
+                      type: string
+                    version:
+                      description: |-
+                        The version of the extension to install. If empty, the operator will
+                        install the default version (whatever is specified in the
+                        extension's control file)
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              icuLocale:
+                description: |-
+                  Maps to the `ICU_LOCALE` parameter of `CREATE DATABASE`. This
+                  setting cannot be changed. Specifies the ICU locale when the ICU
+                  provider is used. This option requires `localeProvider` to be set to
+                  `icu`. Available from PostgreSQL 15.
+                type: string
+                x-kubernetes-validations:
+                - message: icuLocale is immutable
+                  rule: self == oldSelf
+              icuRules:
+                description: |-
+                  Maps to the `ICU_RULES` parameter of `CREATE DATABASE`. This setting
+                  cannot be changed. Specifies additional collation rules to customize
+                  the behavior of the default collation. This option requires
+                  `localeProvider` to be set to `icu`. Available from PostgreSQL 16.
+                type: string
+                x-kubernetes-validations:
+                - message: icuRules is immutable
+                  rule: self == oldSelf
+              isTemplate:
+                description: |-
+                  Maps to the `IS_TEMPLATE` parameter of `CREATE DATABASE` and `ALTER
+                  DATABASE`. If true, this database is considered a template and can
+                  be cloned by any user with `CREATEDB` privileges.
+                type: boolean
+              locale:
+                description: |-
+                  Maps to the `LOCALE` parameter of `CREATE DATABASE`. This setting
+                  cannot be changed. Sets the default collation order and character
+                  classification in the new database.
+                type: string
+                x-kubernetes-validations:
+                - message: locale is immutable
+                  rule: self == oldSelf
+              localeCType:
+                description: |-
+                  Maps to the `LC_CTYPE` parameter of `CREATE DATABASE`. This setting
+                  cannot be changed.
+                type: string
+                x-kubernetes-validations:
+                - message: localeCType is immutable
+                  rule: self == oldSelf
+              localeCollate:
+                description: |-
+                  Maps to the `LC_COLLATE` parameter of `CREATE DATABASE`. This
+                  setting cannot be changed.
+                type: string
+                x-kubernetes-validations:
+                - message: localeCollate is immutable
+                  rule: self == oldSelf
+              localeProvider:
+                description: |-
+                  Maps to the `LOCALE_PROVIDER` parameter of `CREATE DATABASE`. This
+                  setting cannot be changed. This option sets the locale provider for
+                  databases created in the new cluster. Available from PostgreSQL 16.
+                type: string
+                x-kubernetes-validations:
+                - message: localeProvider is immutable
+                  rule: self == oldSelf
+              name:
+                description: The name of the database to create inside PostgreSQL.
+                  This setting cannot be changed.
+                type: string
+                x-kubernetes-validations:
+                - message: name is immutable
+                  rule: self == oldSelf
+                - message: the name postgres is reserved
+                  rule: self != 'postgres'
+                - message: the name template0 is reserved
+                  rule: self != 'template0'
+                - message: the name template1 is reserved
+                  rule: self != 'template1'
+              owner:
+                description: |-
+                  Maps to the `OWNER` parameter of `CREATE DATABASE`.
+                  Maps to the `OWNER TO` command of `ALTER DATABASE`.
+                  The role name of the user who owns the database inside PostgreSQL.
+                type: string
+              schemas:
+                description: The list of schemas to be managed in the database
+                items:
+                  description: SchemaSpec configures a schema in a database
+                  properties:
+                    ensure:
+                      default: present
+                      description: |-
+                        Specifies whether an extension/schema should be present or absent in
+                        the database. If set to `present`, the extension/schema will be
+                        created if it does not exist. If set to `absent`, the
+                        extension/schema will be removed if it exists.
+                      enum:
+                      - present
+                      - absent
+                      type: string
+                    name:
+                      description: Name of the extension/schema
+                      type: string
+                    owner:
+                      description: |-
+                        The role name of the user who owns the schema inside PostgreSQL.
+                        It maps to the `AUTHORIZATION` parameter of `CREATE SCHEMA` and the
+                        `OWNER TO` command of `ALTER SCHEMA`.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              tablespace:
+                description: |-
+                  Maps to the `TABLESPACE` parameter of `CREATE DATABASE`.
+                  Maps to the `SET TABLESPACE` command of `ALTER DATABASE`.
+                  The name of the tablespace (in PostgreSQL) that will be associated
+                  with the new database. This tablespace will be the default
+                  tablespace used for objects created in this database.
+                type: string
+              template:
+                description: |-
+                  Maps to the `TEMPLATE` parameter of `CREATE DATABASE`. This setting
+                  cannot be changed. The name of the template from which to create
+                  this database.
+                type: string
+                x-kubernetes-validations:
+                - message: template is immutable
+                  rule: self == oldSelf
+            required:
+            - cluster
+            - name
+            - owner
+            type: object
+            x-kubernetes-validations:
+            - message: builtinLocale is only available when localeProvider is set
+                to `builtin`
+              rule: '!has(self.builtinLocale) || self.localeProvider == ''builtin'''
+            - message: icuLocale is only available when localeProvider is set to `icu`
+              rule: '!has(self.icuLocale) || self.localeProvider == ''icu'''
+            - message: icuRules is only available when localeProvider is set to `icu`
+              rule: '!has(self.icuRules) || self.localeProvider == ''icu'''
+          status:
+            description: |-
+              Most recently observed status of the Database. This data may not be up to
+              date. Populated by the system. Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              applied:
+                description: Applied is true if the database was reconciled correctly
+                type: boolean
+              extensions:
+                description: Extensions is the status of the managed extensions
+                items:
+                  description: DatabaseObjectStatus is the status of the managed database
+                    objects
+                  properties:
+                    applied:
+                      description: |-
+                        True of the object has been installed successfully in
+                        the database
+                      type: boolean
+                    message:
+                      description: Message is the object reconciliation message
+                      type: string
+                    name:
+                      description: The name of the object
+                      type: string
+                  required:
+                  - applied
+                  - name
+                  type: object
+                type: array
+              message:
+                description: Message is the reconciliation output message
+                type: string
+              observedGeneration:
+                description: |-
+                  A sequence number representing the latest
+                  desired state that was synchronized
+                format: int64
+                type: integer
+              schemas:
+                description: Schemas is the status of the managed schemas
+                items:
+                  description: DatabaseObjectStatus is the status of the managed database
+                    objects
+                  properties:
+                    applied:
+                      description: |-
+                        True of the object has been installed successfully in
+                        the database
+                      type: boolean
+                    message:
+                      description: Message is the object reconciliation message
+                      type: string
+                    name:
+                      description: The name of the object
+                      type: string
+                  required:
+                  - applied
+                  - name
+                  type: object
+                type: array
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/cnpg/postgresql.cnpg.io_failoverquorums.yaml
+++ b/config/crd/cnpg/postgresql.cnpg.io_failoverquorums.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: failoverquorums.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: FailoverQuorum
+    listKind: FailoverQuorumList
+    plural: failoverquorums
+    singular: failoverquorum
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          FailoverQuorum contains the information about the current failover
+          quorum status of a PG cluster. It is updated by the instance manager
+          of the primary node and reset to zero by the operator to trigger
+          an update.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          status:
+            description: Most recently observed status of the failover quorum.
+            properties:
+              method:
+                description: Contains the latest reported Method value.
+                type: string
+              primary:
+                description: |-
+                  Primary is the name of the primary instance that updated
+                  this object the latest time.
+                type: string
+              standbyNames:
+                description: |-
+                  StandbyNames is the list of potentially synchronous
+                  instance names.
+                items:
+                  type: string
+                type: array
+              standbyNumber:
+                description: |-
+                  StandbyNumber is the number of synchronous standbys that transactions
+                  need to wait for replies from.
+                type: integer
+            type: object
+        required:
+        - metadata
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/cnpg/postgresql.cnpg.io_imagecatalogs.yaml
+++ b/config/crd/cnpg/postgresql.cnpg.io_imagecatalogs.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: imagecatalogs.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: ImageCatalog
+    listKind: ImageCatalogList
+    plural: imagecatalogs
+    singular: imagecatalog
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ImageCatalog is the Schema for the imagecatalogs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired behavior of the ImageCatalog.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              images:
+                description: List of CatalogImages available in the catalog
+                items:
+                  description: CatalogImage defines the image and major version
+                  properties:
+                    image:
+                      description: The image reference
+                      type: string
+                    major:
+                      description: The PostgreSQL major version of the image. Must
+                        be unique within the catalog.
+                      minimum: 10
+                      type: integer
+                  required:
+                  - image
+                  - major
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: Images must have unique major versions
+                  rule: self.all(e, self.filter(f, f.major==e.major).size() == 1)
+            required:
+            - images
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/crd/cnpg/postgresql.cnpg.io_poolers.yaml
+++ b/config/crd/cnpg/postgresql.cnpg.io_poolers.yaml
@@ -1,0 +1,8866 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: poolers.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Pooler
+    listKind: PoolerList
+    plural: poolers
+    singular: pooler
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Pooler is the Schema for the poolers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired behavior of the Pooler.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              cluster:
+                description: |-
+                  This is the cluster reference on which the Pooler will work.
+                  Pooler name should never match with any cluster name within the same namespace.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              deploymentStrategy:
+                description: The deployment strategy to use for pgbouncer to replace
+                  existing pods with new ones
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if DeploymentStrategyType =
+                      RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of pods that can be scheduled above the desired number of
+                          pods.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                          the rolling update starts, such that the total number of old and new pods do not exceed
+                          130% of desired pods. Once old pods have been killed,
+                          new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                          at any time during the update is at most 130% of desired pods.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                          immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                          can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                          that the total number of pods available at all times during the update is at
+                          least 70% of desired pods.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              instances:
+                default: 1
+                description: 'The number of replicas we want. Default: 1.'
+                format: int32
+                type: integer
+              monitoring:
+                description: The configuration of the monitoring infrastructure of
+                  this pooler.
+                properties:
+                  enablePodMonitor:
+                    default: false
+                    description: Enable or disable the `PodMonitor`
+                    type: boolean
+                  podMonitorMetricRelabelings:
+                    description: The list of metric relabelings for the `PodMonitor`.
+                      Applied to samples before ingestion.
+                    items:
+                      description: |-
+                        RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                        scraped samples and remote write samples.
+
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                      properties:
+                        action:
+                          default: replace
+                          description: |-
+                            Action to perform based on the regex matching.
+
+                            `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                            `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                            Default: "Replace"
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: |-
+                            Modulus to take of the hash of the source label values.
+
+                            Only applicable when the action is `HashMod`.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched.
+                          type: string
+                        replacement:
+                          description: |-
+                            Replacement value against which a Replace action is performed if the
+                            regular expression matches.
+
+                            Regex capture groups are available.
+                          type: string
+                        separator:
+                          description: Separator is the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: |-
+                            The source labels select values from existing labels. Their content is
+                            concatenated using the configured Separator and matched against the
+                            configured regular expression.
+                          items:
+                            description: |-
+                              LabelName is a valid Prometheus label name which may only contain ASCII
+                              letters, numbers, as well as underscores.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: |-
+                            Label to which the resulting string is written in a replacement.
+
+                            It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                            `KeepEqual` and `DropEqual` actions.
+
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
+                  podMonitorRelabelings:
+                    description: The list of relabelings for the `PodMonitor`. Applied
+                      to samples before scraping.
+                    items:
+                      description: |-
+                        RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                        scraped samples and remote write samples.
+
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                      properties:
+                        action:
+                          default: replace
+                          description: |-
+                            Action to perform based on the regex matching.
+
+                            `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                            `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                            Default: "Replace"
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: |-
+                            Modulus to take of the hash of the source label values.
+
+                            Only applicable when the action is `HashMod`.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched.
+                          type: string
+                        replacement:
+                          description: |-
+                            Replacement value against which a Replace action is performed if the
+                            regular expression matches.
+
+                            Regex capture groups are available.
+                          type: string
+                        separator:
+                          description: Separator is the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: |-
+                            The source labels select values from existing labels. Their content is
+                            concatenated using the configured Separator and matched against the
+                            configured regular expression.
+                          items:
+                            description: |-
+                              LabelName is a valid Prometheus label name which may only contain ASCII
+                              letters, numbers, as well as underscores.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: |-
+                            Label to which the resulting string is written in a replacement.
+
+                            It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                            `KeepEqual` and `DropEqual` actions.
+
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              pgbouncer:
+                description: The PgBouncer configuration
+                properties:
+                  authQuery:
+                    description: |-
+                      The query that will be used to download the hash of the password
+                      of a certain user. Default: "SELECT usename, passwd FROM public.user_search($1)".
+                      In case it is specified, also an AuthQuerySecret has to be specified and
+                      no automatic CNPG Cluster integration will be triggered.
+                    type: string
+                  authQuerySecret:
+                    description: |-
+                      The credentials of the user that need to be used for the authentication
+                      query. In case it is specified, also an AuthQuery
+                      (e.g. "SELECT usename, passwd FROM pg_catalog.pg_shadow WHERE usename=$1")
+                      has to be specified and no automatic CNPG Cluster integration will be triggered.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Additional parameters to be passed to PgBouncer - please check
+                      the CNPG documentation for a list of options you can configure
+                    type: object
+                  paused:
+                    default: false
+                    description: |-
+                      When set to `true`, PgBouncer will disconnect from the PostgreSQL
+                      server, first waiting for all queries to complete, and pause all new
+                      client connections until this value is set to `false` (default). Internally,
+                      the operator calls PgBouncer's `PAUSE` and `RESUME` commands.
+                    type: boolean
+                  pg_hba:
+                    description: |-
+                      PostgreSQL Host Based Authentication rules (lines to be appended
+                      to the pg_hba.conf file)
+                    items:
+                      type: string
+                    type: array
+                  poolMode:
+                    default: session
+                    description: 'The pool mode. Default: `session`.'
+                    enum:
+                    - session
+                    - transaction
+                    type: string
+                type: object
+              serviceTemplate:
+                description: Template for the Service to be created
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: The name of the resource. Only supported for
+                          certain types
+                        type: string
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the service.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        description: |-
+                          allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                          allocated for services with type LoadBalancer.  Default is "true". It
+                          may be set to "false" if the cluster load-balancer does not rely on
+                          NodePorts.  If the caller requests specific NodePorts (by specifying a
+                          value), those requests will be respected, regardless of this field.
+                          This field may only be set for services with type LoadBalancer and will
+                          be cleared if the type is changed to any other type.
+                        type: boolean
+                      clusterIP:
+                        description: |-
+                          clusterIP is the IP address of the service and is usually assigned
+                          randomly. If an address is specified manually, is in-range (as per
+                          system configuration), and is not in use, it will be allocated to the
+                          service; otherwise creation of the service will fail. This field may not
+                          be changed through updates unless the type field is also being changed
+                          to ExternalName (which requires this field to be blank) or the type
+                          field is being changed from ExternalName (in which case this field may
+                          optionally be specified, as describe above).  Valid values are "None",
+                          empty string (""), or a valid IP address. Setting this to "None" makes a
+                          "headless service" (no virtual IP), which is useful when direct endpoint
+                          connections are preferred and proxying is not required.  Only applies to
+                          types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                          when creating a Service of type ExternalName, creation will fail. This
+                          field will be wiped when updating a Service to type ExternalName.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        type: string
+                      clusterIPs:
+                        description: |-
+                          ClusterIPs is a list of IP addresses assigned to this service, and are
+                          usually assigned randomly.  If an address is specified manually, is
+                          in-range (as per system configuration), and is not in use, it will be
+                          allocated to the service; otherwise creation of the service will fail.
+                          This field may not be changed through updates unless the type field is
+                          also being changed to ExternalName (which requires this field to be
+                          empty) or the type field is being changed from ExternalName (in which
+                          case this field may optionally be specified, as describe above).  Valid
+                          values are "None", empty string (""), or a valid IP address.  Setting
+                          this to "None" makes a "headless service" (no virtual IP), which is
+                          useful when direct endpoint connections are preferred and proxying is
+                          not required.  Only applies to types ClusterIP, NodePort, and
+                          LoadBalancer. If this field is specified when creating a Service of type
+                          ExternalName, creation will fail. This field will be wiped when updating
+                          a Service to type ExternalName.  If this field is not specified, it will
+                          be initialized from the clusterIP field.  If this field is specified,
+                          clients must ensure that clusterIPs[0] and clusterIP have the same
+                          value.
+
+                          This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                          These IPs must correspond to the values of the ipFamilies field. Both
+                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        description: |-
+                          externalIPs is a list of IP addresses for which nodes in the cluster
+                          will also accept traffic for this service.  These IPs are not managed by
+                          Kubernetes.  The user is responsible for ensuring that traffic arrives
+                          at a node with this IP.  A common example is external load-balancers
+                          that are not part of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalName:
+                        description: |-
+                          externalName is the external reference that discovery mechanisms will
+                          return as an alias for this service (e.g. a DNS CNAME record). No
+                          proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                          (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                        type: string
+                      externalTrafficPolicy:
+                        description: |-
+                          externalTrafficPolicy describes how nodes distribute service traffic they
+                          receive on one of the Service's "externally-facing" addresses (NodePorts,
+                          ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                          the service in a way that assumes that external load balancers will take care
+                          of balancing the service traffic between nodes, and so each node will deliver
+                          traffic only to the node-local endpoints of the service, without masquerading
+                          the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                          be dropped.) The default value, "Cluster", uses the standard behavior of
+                          routing to all endpoints evenly (possibly modified by topology and other
+                          features). Note that traffic sent to an External IP or LoadBalancer IP from
+                          within the cluster will always get "Cluster" semantics, but clients sending to
+                          a NodePort from within the cluster may need to take traffic policy into account
+                          when picking a node.
+                        type: string
+                      healthCheckNodePort:
+                        description: |-
+                          healthCheckNodePort specifies the healthcheck nodePort for the service.
+                          This only applies when type is set to LoadBalancer and
+                          externalTrafficPolicy is set to Local. If a value is specified, is
+                          in-range, and is not in use, it will be used.  If not specified, a value
+                          will be automatically allocated.  External systems (e.g. load-balancers)
+                          can use this port to determine if a given node holds endpoints for this
+                          service or not.  If this field is specified when creating a Service
+                          which does not need it, creation will fail. This field will be wiped
+                          when updating a Service to no longer need it (e.g. changing type).
+                          This field cannot be updated once set.
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        description: |-
+                          InternalTrafficPolicy describes how nodes distribute service traffic they
+                          receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                          only want to talk to endpoints of the service on the same node as the pod,
+                          dropping the traffic if there are no local endpoints. The default value,
+                          "Cluster", uses the standard behavior of routing to all endpoints evenly
+                          (possibly modified by topology and other features).
+                        type: string
+                      ipFamilies:
+                        description: |-
+                          IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                          service. This field is usually assigned automatically based on cluster
+                          configuration and the ipFamilyPolicy field. If this field is specified
+                          manually, the requested family is available in the cluster,
+                          and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                          the service will fail. This field is conditionally mutable: it allows
+                          for adding or removing a secondary IP family, but it does not allow
+                          changing the primary IP family of the Service. Valid values are "IPv4"
+                          and "IPv6".  This field only applies to Services of types ClusterIP,
+                          NodePort, and LoadBalancer, and does apply to "headless" services.
+                          This field will be wiped when updating a Service to type ExternalName.
+
+                          This field may hold a maximum of two entries (dual-stack families, in
+                          either order).  These families must correspond to the values of the
+                          clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                          governed by the ipFamilyPolicy field.
+                        items:
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        description: |-
+                          IPFamilyPolicy represents the dual-stack-ness requested or required by
+                          this Service. If there is no value provided, then this field will be set
+                          to SingleStack. Services can be "SingleStack" (a single IP family),
+                          "PreferDualStack" (two IP families on dual-stack configured clusters or
+                          a single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise fail). The
+                          ipFamilies and clusterIPs fields depend on the value of this field. This
+                          field will be wiped when updating a service to type ExternalName.
+                        type: string
+                      loadBalancerClass:
+                        description: |-
+                          loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                          If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                          e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                          This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                          balancer implementation is used, today this is typically done through the cloud provider integration,
+                          but should apply for any default implementation. If set, it is assumed that a load balancer
+                          implementation is watching for Services with a matching class. Any default load balancer
+                          implementation (e.g. cloud providers) should ignore Services that set this field.
+                          This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                          Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                        type: string
+                      loadBalancerIP:
+                        description: |-
+                          Only applies to Service Type: LoadBalancer.
+                          This feature depends on whether the underlying cloud-provider supports specifying
+                          the loadBalancerIP when a load balancer is created.
+                          This field will be ignored if the cloud-provider does not support the feature.
+                          Deprecated: This field was under-specified and its meaning varies across implementations.
+                          Using it is non-portable and it may not support dual-stack.
+                          Users are encouraged to use implementation-specific annotations when available.
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: |-
+                          If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                          load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                          cloud-provider does not support the feature."
+                          More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ports:
+                        description: |-
+                          The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: |-
+                                The application protocol for this port.
+                                This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                This field follows standard Kubernetes label syntax.
+                                Valid values are either:
+
+                                * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                RFC-6335 and https://www.iana.org/assignments/service-names).
+
+                                * Kubernetes-defined prefixed names:
+                                  * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                  * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                  * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+                                * Other protocols should use implementation-defined prefixed names such as
+                                mycompany.com/my-custom-protocol.
+                              type: string
+                            name:
+                              description: |-
+                                The name of this port within the service. This must be a DNS_LABEL.
+                                All ports within a ServiceSpec must have unique names. When considering
+                                the endpoints for a Service, this must match the 'name' field in the
+                                EndpointPort.
+                                Optional if only one ServicePort is defined on this service.
+                              type: string
+                            nodePort:
+                              description: |-
+                                The port on each node on which this service is exposed when type is
+                                NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                specified, in-range, and not in use it will be used, otherwise the
+                                operation will fail.  If not specified, a port will be allocated if this
+                                Service requires one.  If this field is specified when creating a
+                                Service which does not need it, creation will fail. This field will be
+                                wiped when updating a Service to no longer need it (e.g. changing type
+                                from NodePort to ClusterIP).
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: |-
+                                The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Number or name of the port to access on the pods targeted by the service.
+                                Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named port in the
+                                target Pod's container ports. If this is not specified, the value
+                                of the 'port' field is used (an identity map).
+                                This field is ignored for services with clusterIP=None, and should be
+                                omitted or set equal to the 'port' field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: |-
+                          publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                          Service should disregard any indications of ready/not-ready.
+                          The primary use case for setting this field is for a StatefulSet's Headless Service to
+                          propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                          The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                          Services interpret this to mean that all endpoints are considered "ready" even if the
+                          Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                          through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Route service traffic to pods with label keys and values matching this
+                          selector. If empty or not present, the service is assumed to have an
+                          external process managing its endpoints, which Kubernetes will not
+                          modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                          Ignored if type is ExternalName.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sessionAffinity:
+                        description: |-
+                          Supports "ClientIP" and "None". Used to maintain session affinity.
+                          Enable client IP based session affinity.
+                          Must be ClientIP or None.
+                          Defaults to None.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: |-
+                                  timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                  The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                  Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      trafficDistribution:
+                        description: |-
+                          TrafficDistribution offers a way to express preferences for how traffic
+                          is distributed to Service endpoints. Implementations can use this field
+                          as a hint, but are not required to guarantee strict adherence. If the
+                          field is not set, the implementation will apply its default routing
+                          strategy. If set to "PreferClose", implementations should prioritize
+                          endpoints that are in the same zone.
+                        type: string
+                      type:
+                        description: |-
+                          type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                          options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                          "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                          to endpoints. Endpoints are determined by the selector or if that is not
+                          specified, by manual construction of an Endpoints object or
+                          EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                          allocated and the endpoints are published as a set of endpoints rather
+                          than a virtual IP.
+                          "NodePort" builds on ClusterIP and allocates a port on every node which
+                          routes to the same endpoints as the clusterIP.
+                          "LoadBalancer" builds on NodePort and creates an external load-balancer
+                          (if supported in the current cloud) which routes to the same endpoints
+                          as the clusterIP.
+                          "ExternalName" aliases this service to the specified externalName.
+                          Several other fields do not apply to ExternalName services.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                        type: string
+                    type: object
+                type: object
+              template:
+                description: The template of the Pod to be created
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: The name of the resource. Only supported for
+                          certain types
+                        type: string
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      activeDeadlineSeconds:
+                        description: |-
+                          Optional duration in seconds the pod may be active on the node relative to
+                          StartTime before the system will actively try to mark it failed and kill associated containers.
+                          Value must be a positive integer.
+                        format: int64
+                        type: integer
+                      affinity:
+                        description: If specified, the pod's scheduling constraints
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      automountServiceAccountToken:
+                        description: AutomountServiceAccountToken indicates whether
+                          a service account token should be automatically mounted.
+                        type: boolean
+                      containers:
+                        description: |-
+                          List of containers belonging to the pod.
+                          Containers cannot currently be added or removed.
+                          There must be at least one container in a Pod.
+                          Cannot be updated.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps or Secrets
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  prefix:
+                                    description: Optional text to prepend to the name
+                                      of each environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            image:
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                              type: string
+                            lifecycle:
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
+                              properties:
+                                postStart:
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
+                              type: object
+                            livenessProbe:
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resizePolicy:
+                              description: Resources resize policy for the container.
+                              items:
+                                description: ContainerResizePolicy represents resource
+                                  resize policy for the container.
+                                properties:
+                                  resourceName:
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
+                                    type: string
+                                  restartPolicy:
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            resources:
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            restartPolicy:
+                              description: |-
+                                RestartPolicy defines the restart behavior of individual containers in a pod.
+                                This field may only be set for init containers, and the only allowed value is "Always".
+                                For non-init containers or when this field is not specified,
+                                the restart behavior is defined by the Pod's restart policy and the container type.
+                                Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                this init container will be continually restarted on
+                                exit until all regular containers have terminated. Once all regular
+                                containers have completed, all init containers with restartPolicy "Always"
+                                will be shut down. This lifecycle differs from normal init containers and
+                                is often referred to as a "sidecar" container. Although this init
+                                container still starts in the init container sequence, it does not wait
+                                for the container to complete before proceeding to the next init
+                                container. Instead, the next init container starts immediately after this
+                                init container is started, or after any startupProbe has successfully
+                                completed.
+                              type: string
+                            securityContext:
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                capabilities:
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                procMount:
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default value is Default which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
+                              type: string
+                            tty:
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
+                                  subPath:
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      dnsConfig:
+                        description: |-
+                          Specifies the DNS parameters of a pod.
+                          Parameters specified here will be merged to the generated DNS
+                          configuration based on DNSPolicy.
+                        properties:
+                          nameservers:
+                            description: |-
+                              A list of DNS name server IP addresses.
+                              This will be appended to the base nameservers generated from DNSPolicy.
+                              Duplicated nameservers will be removed.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            description: |-
+                              A list of DNS resolver options.
+                              This will be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options given in Options
+                              will override those that appear in the base DNSPolicy.
+                            items:
+                              description: PodDNSConfigOption defines DNS resolver
+                                options of a pod.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is this DNS resolver option's name.
+                                    Required.
+                                  type: string
+                                value:
+                                  description: Value is this DNS resolver option's
+                                    value.
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            description: |-
+                              A list of DNS search domains for host-name lookup.
+                              This will be appended to the base search paths generated from DNSPolicy.
+                              Duplicated search paths will be removed.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        description: |-
+                          Set DNS policy for the pod.
+                          Defaults to "ClusterFirst".
+                          Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                          DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                          To have DNS options set along with hostNetwork, you have to specify DNS policy
+                          explicitly to 'ClusterFirstWithHostNet'.
+                        type: string
+                      enableServiceLinks:
+                        description: |-
+                          EnableServiceLinks indicates whether information about services should be injected into pod's
+                          environment variables, matching the syntax of Docker links.
+                          Optional: Defaults to true.
+                        type: boolean
+                      ephemeralContainers:
+                        description: |-
+                          List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                          pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                          creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                          ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
+                        items:
+                          description: |-
+                            An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                            user-initiated activities such as debugging. Ephemeral containers have no resource or
+                            scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                            removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                            Pod to exceed its resource allocation.
+
+                            To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                            Pod. Ephemeral containers may not be removed or restarted.
+                          properties:
+                            args:
+                              description: |-
+                                Arguments to the entrypoint.
+                                The image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps or Secrets
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  prefix:
+                                    description: Optional text to prepend to the name
+                                      of each environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            image:
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                              type: string
+                            lifecycle:
+                              description: Lifecycle is not allowed for ephemeral
+                                containers.
+                              properties:
+                                postStart:
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
+                              type: object
+                            livenessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: |-
+                                Name of the ephemeral container specified as a DNS_LABEL.
+                                This name must be unique among all containers, init containers and ephemeral containers.
+                              type: string
+                            ports:
+                              description: Ports are not allowed for ephemeral containers.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resizePolicy:
+                              description: Resources resize policy for the container.
+                              items:
+                                description: ContainerResizePolicy represents resource
+                                  resize policy for the container.
+                                properties:
+                                  resourceName:
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
+                                    type: string
+                                  restartPolicy:
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            resources:
+                              description: |-
+                                Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+                                already allocated to the pod.
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            restartPolicy:
+                              description: |-
+                                Restart policy for the container to manage the restart behavior of each
+                                container within a pod.
+                                This may only be set for init containers. You cannot set this field on
+                                ephemeral containers.
+                              type: string
+                            securityContext:
+                              description: |-
+                                Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                capabilities:
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                procMount:
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default value is Default which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
+                              type: boolean
+                            targetContainerName:
+                              description: |-
+                                If set, the name of the container from PodSpec that this ephemeral container targets.
+                                The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                The container runtime must implement support for this feature. If the runtime does not
+                                support namespace targeting then the result of setting this field is undefined.
+                              type: string
+                            terminationMessagePath:
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
+                              type: string
+                            tty:
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: |-
+                                Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
+                                  subPath:
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      hostAliases:
+                        description: |-
+                          HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                          file if specified.
+                        items:
+                          description: |-
+                            HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                            pod's hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - ip
+                        x-kubernetes-list-type: map
+                      hostIPC:
+                        description: |-
+                          Use the host's ipc namespace.
+                          Optional: Default to false.
+                        type: boolean
+                      hostNetwork:
+                        description: |-
+                          Host networking requested for this pod. Use the host's network namespace.
+                          If this option is set, the ports that will be used must be specified.
+                          Default to false.
+                        type: boolean
+                      hostPID:
+                        description: |-
+                          Use the host's pid namespace.
+                          Optional: Default to false.
+                        type: boolean
+                      hostUsers:
+                        description: |-
+                          Use the host's user namespace.
+                          Optional: Default to true.
+                          If set to true or not present, the pod will be run in the host user namespace, useful
+                          for when the pod needs a feature only available to the host user namespace, such as
+                          loading a kernel module with CAP_SYS_MODULE.
+                          When set to false, a new userns is created for the pod. Setting false is useful for
+                          mitigating container breakout vulnerabilities even allowing users to run their
+                          containers as root without actually having root privileges on the host.
+                          This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
+                        type: boolean
+                      hostname:
+                        description: |-
+                          Specifies the hostname of the Pod
+                          If not specified, the pod's hostname will be set to a system-defined value.
+                        type: string
+                      imagePullSecrets:
+                        description: |-
+                          ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                          If specified, these secrets will be passed to individual puller implementations for them to use.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      initContainers:
+                        description: |-
+                          List of initialization containers belonging to the pod.
+                          Init containers are executed in order prior to containers being started. If any
+                          init container fails, the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or normal container must be
+                          unique among all containers.
+                          Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                          The resourceRequirements of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type, and then using the max of
+                          that value or the sum of the normal containers. Limits are applied to init containers
+                          in a similar fashion.
+                          Init containers cannot currently be added or removed.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps or Secrets
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  prefix:
+                                    description: Optional text to prepend to the name
+                                      of each environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            image:
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                              type: string
+                            lifecycle:
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
+                              properties:
+                                postStart:
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
+                              type: object
+                            livenessProbe:
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resizePolicy:
+                              description: Resources resize policy for the container.
+                              items:
+                                description: ContainerResizePolicy represents resource
+                                  resize policy for the container.
+                                properties:
+                                  resourceName:
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
+                                    type: string
+                                  restartPolicy:
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            resources:
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            restartPolicy:
+                              description: |-
+                                RestartPolicy defines the restart behavior of individual containers in a pod.
+                                This field may only be set for init containers, and the only allowed value is "Always".
+                                For non-init containers or when this field is not specified,
+                                the restart behavior is defined by the Pod's restart policy and the container type.
+                                Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                this init container will be continually restarted on
+                                exit until all regular containers have terminated. Once all regular
+                                containers have completed, all init containers with restartPolicy "Always"
+                                will be shut down. This lifecycle differs from normal init containers and
+                                is often referred to as a "sidecar" container. Although this init
+                                container still starts in the init container sequence, it does not wait
+                                for the container to complete before proceeding to the next init
+                                container. Instead, the next init container starts immediately after this
+                                init container is started, or after any startupProbe has successfully
+                                completed.
+                              type: string
+                            securityContext:
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                capabilities:
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                procMount:
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default value is Default which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
+                              type: string
+                            tty:
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
+                                  subPath:
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      nodeName:
+                        description: |-
+                          NodeName indicates in which node this pod is scheduled.
+                          If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.
+                          Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.
+                          This field should not be used to express a desire for the pod to be scheduled on a specific node.
+                          https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          NodeSelector is a selector which must be true for the pod to fit on a node.
+                          Selector which must match a node's labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      os:
+                        description: |-
+                          Specifies the OS of the containers in the pod.
+                          Some pod and container fields are restricted if this is set.
+
+                          If the OS field is set to linux, the following fields must be unset:
+                          -securityContext.windowsOptions
+
+                          If the OS field is set to windows, following fields must be unset:
+                          - spec.hostPID
+                          - spec.hostIPC
+                          - spec.hostUsers
+                          - spec.securityContext.appArmorProfile
+                          - spec.securityContext.seLinuxOptions
+                          - spec.securityContext.seccompProfile
+                          - spec.securityContext.fsGroup
+                          - spec.securityContext.fsGroupChangePolicy
+                          - spec.securityContext.sysctls
+                          - spec.shareProcessNamespace
+                          - spec.securityContext.runAsUser
+                          - spec.securityContext.runAsGroup
+                          - spec.securityContext.supplementalGroups
+                          - spec.securityContext.supplementalGroupsPolicy
+                          - spec.containers[*].securityContext.appArmorProfile
+                          - spec.containers[*].securityContext.seLinuxOptions
+                          - spec.containers[*].securityContext.seccompProfile
+                          - spec.containers[*].securityContext.capabilities
+                          - spec.containers[*].securityContext.readOnlyRootFilesystem
+                          - spec.containers[*].securityContext.privileged
+                          - spec.containers[*].securityContext.allowPrivilegeEscalation
+                          - spec.containers[*].securityContext.procMount
+                          - spec.containers[*].securityContext.runAsUser
+                          - spec.containers[*].securityContext.runAsGroup
+                        properties:
+                          name:
+                            description: |-
+                              Name is the name of the operating system. The currently supported values are linux and windows.
+                              Additional value may be defined in future and can be one of:
+                              https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                              Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                          This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                          the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                          set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                          defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                        type: object
+                      preemptionPolicy:
+                        description: |-
+                          PreemptionPolicy is the Policy for preempting pods with lower priority.
+                          One of Never, PreemptLowerPriority.
+                          Defaults to PreemptLowerPriority if unset.
+                        type: string
+                      priority:
+                        description: |-
+                          The priority value. Various system components use this field to find the
+                          priority of the pod. When Priority Admission Controller is enabled, it
+                          prevents users from setting this field. The admission controller populates
+                          this field from PriorityClassName.
+                          The higher the value, the higher the priority.
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        description: |-
+                          If specified, indicates the pod's priority. "system-node-critical" and
+                          "system-cluster-critical" are two special keywords which indicate the
+                          highest priorities with the former being the highest priority. Any other
+                          name must be defined by creating a PriorityClass object with that name.
+                          If not specified, the pod priority will be default or zero if there is no
+                          default.
+                        type: string
+                      readinessGates:
+                        description: |-
+                          If specified, all readiness gates will be evaluated for pod readiness.
+                          A pod is ready when all its containers are ready AND
+                          all conditions specified in the readiness gates have status equal to "True"
+                          More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+                        items:
+                          description: PodReadinessGate contains the reference to
+                            a pod condition
+                          properties:
+                            conditionType:
+                              description: ConditionType refers to a condition in
+                                the pod's condition list with matching type.
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      resourceClaims:
+                        description: |-
+                          ResourceClaims defines which ResourceClaims must be allocated
+                          and reserved before the Pod is allowed to start. The resources
+                          will be made available to those containers which consume them
+                          by name.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable.
+                        items:
+                          description: |-
+                            PodResourceClaim references exactly one ResourceClaim, either directly
+                            or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                            for the pod.
+
+                            It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                            Containers that need access to the ResourceClaim reference it with this name.
+                          properties:
+                            name:
+                              description: |-
+                                Name uniquely identifies this resource claim inside the pod.
+                                This must be a DNS_LABEL.
+                              type: string
+                            resourceClaimName:
+                              description: |-
+                                ResourceClaimName is the name of a ResourceClaim object in the same
+                                namespace as this pod.
+
+                                Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                be set.
+                              type: string
+                            resourceClaimTemplateName:
+                              description: |-
+                                ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                object in the same namespace as this pod.
+
+                                The template will be used to create a new ResourceClaim, which will
+                                be bound to this pod. When this pod is deleted, the ResourceClaim
+                                will also be deleted. The pod name and resource name, along with a
+                                generated component, will be used to form a unique name for the
+                                ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                This field is immutable and no changes will be made to the
+                                corresponding ResourceClaim by the control plane after creating the
+                                ResourceClaim.
+
+                                Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                be set.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      resources:
+                        description: |-
+                          Resources is the total amount of CPU and Memory resources required by all
+                          containers in the pod. It supports specifying Requests and Limits for
+                          "cpu" and "memory" resource names only. ResourceClaims are not supported.
+
+                          This field enables fine-grained control over resource allocation for the
+                          entire pod, allowing resource sharing among containers in a pod.
+
+                          This is an alpha field and requires enabling the PodLevelResources feature
+                          gate.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      restartPolicy:
+                        description: |-
+                          Restart policy for all containers within the pod.
+                          One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                          Default to Always.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+                        type: string
+                      runtimeClassName:
+                        description: |-
+                          RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                          to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                          If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                          empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+                        type: string
+                      schedulerName:
+                        description: |-
+                          If specified, the pod will be dispatched by specified scheduler.
+                          If not specified, the pod will be dispatched by default scheduler.
+                        type: string
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                          If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                          scheduler will not attempt to schedule the pod.
+
+                          SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      securityContext:
+                        description: |-
+                          SecurityContext holds pod-level security attributes and common container settings.
+                          Optional: Defaults to empty.  See type description for default values of each field.
+                        properties:
+                          appArmorProfile:
+                            description: |-
+                              appArmorProfile is the AppArmor options to use by the containers in this pod.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile loaded on the node that should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must match the loaded name of the profile.
+                                  Must be set if and only if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of AppArmor profile will be applied.
+                                  Valid options are:
+                                    Localhost - a profile pre-loaded on the node.
+                                    RuntimeDefault - the container runtime's default profile.
+                                    Unconfined - no AppArmor enforcement.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          fsGroup:
+                            description: |-
+                              A special supplemental group that applies to all containers in a pod.
+                              Some volume types allow the Kubelet to change the ownership of that volume
+                              to be owned by the pod:
+
+                              1. The owning GID will be the FSGroup
+                              2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                              3. The permission bits are OR'd with rw-rw----
+
+                              If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            description: |-
+                              fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                              before being exposed inside Pod. This field will only apply to
+                              volume types which support fsGroup based ownership(and permissions).
+                              It will have no effect on ephemeral volume types such as: secret, configmaps
+                              and emptydir.
+                              Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: string
+                          runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            description: |-
+                              seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                              It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                              Valid values are "MountOption" and "Recursive".
+
+                              "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                              This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                              "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                              This requires all Pods that share the same volume to use the same SELinux label.
+                              It is not possible to share the same volume among privileged and unprivileged Pods.
+                              Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                              whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                              CSIDriver instance. Other volumes are always re-labelled recursively.
+                              "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                              If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                              If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                              and "Recursive" for all other volumes.
+
+                              This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                              All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: string
+                          seLinuxOptions:
+                            description: |-
+                              The SELinux context to be applied to all containers.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in SecurityContext.  If set in
+                              both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: |-
+                              The seccomp options to use by the containers in this pod.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          supplementalGroups:
+                            description: |-
+                              A list of groups applied to the first process run in each container, in
+                              addition to the container's primary GID and fsGroup (if specified).  If
+                              the SupplementalGroupsPolicy feature is enabled, the
+                              supplementalGroupsPolicy field determines whether these are in addition
+                              to or instead of any group memberships defined in the container image.
+                              If unspecified, no additional groups are added, though group memberships
+                              defined in the container image may still be used, depending on the
+                              supplementalGroupsPolicy field.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            description: |-
+                              Defines how supplemental groups of the first container processes are calculated.
+                              Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                              (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                              and the container runtime must implement support for this feature.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: string
+                          sysctls:
+                            description: |-
+                              Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                              sysctls (by the container runtime) might fail to launch.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
+                              properties:
+                                name:
+                                  description: Name of a property to set
+                                  type: string
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options within a container's SecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        description: |-
+                          DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
+                          Deprecated: Use serviceAccountName instead.
+                        type: string
+                      serviceAccountName:
+                        description: |-
+                          ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                        type: string
+                      setHostnameAsFQDN:
+                        description: |-
+                          If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                          In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                          In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                          If a pod does not have FQDN, this has no effect.
+                          Default to false.
+                        type: boolean
+                      shareProcessNamespace:
+                        description: |-
+                          Share a single process namespace between all of the containers in a pod.
+                          When this is set containers will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container will not be assigned PID 1.
+                          HostPID and ShareProcessNamespace cannot both be set.
+                          Optional: Default to false.
+                        type: boolean
+                      subdomain:
+                        description: |-
+                          If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                          If not specified, the pod will not have a domainname at all.
+                        type: string
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          If this value is nil, the default grace period will be used instead.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          Defaults to 30 seconds.
+                        format: int64
+                        type: integer
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. Scheduler will schedule pods in a way which abides by the constraints.
+                          All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                              type: string
+                            topologyKey:
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - topologyKey
+                        - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      volumes:
+                        description: |-
+                          List of volumes that can be mounted by containers belonging to the pod.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes
+                        items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: |-
+                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  type: string
+                                partition:
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: |-
+                                    readOnly value true will force the readOnly setting in VolumeMounts.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  type: boolean
+                                volumeID:
+                                  description: |-
+                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              description: |-
+                                azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                are redirected to the disk.csi.azure.com CSI driver.
+                              properties:
+                                cachingMode:
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
+                                  type: string
+                                diskName:
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
+                                  type: string
+                                diskURI:
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  description: |-
+                                    fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              description: |-
+                                azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                are redirected to the file.csi.azure.com CSI driver.
+                              properties:
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: shareName is the azure share Name
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              description: |-
+                                cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                              properties:
+                                monitors:
+                                  description: |-
+                                    monitors is Required: Monitors is a collection of Ceph monitors
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  type: boolean
+                                secretFile:
+                                  description: |-
+                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  description: |-
+                                    user is optional: User is the rados user name, default is admin
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              description: |-
+                                cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                are redirected to the cinder.csi.openstack.org CSI driver.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef is optional: points to a secret object containing parameters used to connect
+                                    to OpenStack.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  description: |-
+                                    volumeID used to identify the volume in cinder.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              description: configMap represents a configMap that should
+                                populate this volume
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    defaultMode is optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the ConfigMap,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers.
+                              properties:
+                                driver:
+                                  description: |-
+                                    driver is the name of the CSI driver that handles this volume.
+                                    Consult with your admin for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: |-
+                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                    If not provided, the empty value is passed to the associated CSI driver
+                                    which will determine the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: |-
+                                    nodePublishSecretRef is a reference to the secret object containing
+                                    sensitive information to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no secret is required. If the
+                                    secret object contains more than one secret, all secret references are passed.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  description: |-
+                                    readOnly specifies a read-only configuration for the volume.
+                                    Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    volumeAttributes stores driver-specific properties that are passed to the CSI
+                                    driver. Consult your driver's documentation for supported values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    Optional: mode bits to use on created files by default. Must be a
+                                    Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name,
+                                          namespace and uid are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        description: |-
+                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              description: |-
+                                emptyDir represents a temporary directory that shares a pod's lifetime.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                              properties:
+                                medium:
+                                  description: |-
+                                    medium represents what type of storage medium should back this directory.
+                                    The default is "" which means to use the node's default medium.
+                                    Must be an empty string (default) or Memory.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                    The size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would be the minimum value between
+                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                    The default is nil which means that the limit is undefined.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver.
+                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                and deleted when the pod is removed.
+
+                                Use this if:
+                                a) the volume is only needed while the pod runs,
+                                b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and
+                                d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+                                Use PersistentVolumeClaim or one of the vendor-specific
+                                APIs for volumes that persist for longer than the lifecycle
+                                of an individual pod.
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                be used that way - see the documentation of the driver for
+                                more information.
+
+                                A pod can use both types of ephemeral volumes and
+                                persistent volumes at the same time.
+                              properties:
+                                volumeClaimTemplate:
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume.
+                                    The pod in which this EphemeralVolumeSource is embedded will be the
+                                    owner of the PVC, i.e. the PVC will be deleted together with the
+                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                    `<volume name>` is the name from the `PodSpec.Volumes` array
+                                    entry. Pod validation will reject the pod if the concatenated name
+                                    is not valid for a PVC (for example, too long).
+
+                                    An existing PVC with that name that is not owned by the pod
+                                    will *not* be used for the pod to avoid using an unrelated
+                                    volume by mistake. Starting the pod is then blocked until
+                                    the unrelated PVC is removed. If such a pre-created PVC is
+                                    meant to be used by the pod, the PVC has to updated with an
+                                    owner reference to the pod once the pod exists. Normally
+                                    this should not be necessary, but it may be useful when
+                                    manually reconstructing a broken cluster.
+
+                                    This field is read-only and no changes will be made by Kubernetes
+                                    to the PVC after it has been created.
+
+                                    Required, must not be nil.
+                                  properties:
+                                    metadata:
+                                      description: |-
+                                        May contain labels and annotations that will be copied into the PVC
+                                        when creating it. No other fields are allowed and will be rejected during
+                                        validation.
+                                      type: object
+                                    spec:
+                                      description: |-
+                                        The specification for the PersistentVolumeClaim. The entire content is
+                                        copied unchanged into the PVC that gets created from this
+                                        template. The same fields as in a PersistentVolumeClaim
+                                        are also valid here.
+                                      properties:
+                                        accessModes:
+                                          description: |-
+                                            accessModes contains the desired access modes the volume should have.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          description: |-
+                                            dataSource field can be used to specify either:
+                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                            * An existing PVC (PersistentVolumeClaim)
+                                            If the provisioner or an external controller can support the specified data source,
+                                            it will create a new volume based on the contents of the specified data source.
+                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                          properties:
+                                            apiGroup:
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                            volume is desired. This may be any object from a non-empty API group (non
+                                            core object) or a PersistentVolumeClaim object.
+                                            When this field is specified, volume binding will only succeed if the type of
+                                            the specified object matches some installed volume populator or dynamic
+                                            provisioner.
+                                            This field will replace the functionality of the dataSource field and as such
+                                            if both fields are non-empty, they must have the same value. For backwards
+                                            compatibility, when namespace isn't specified in dataSourceRef,
+                                            both fields (dataSource and dataSourceRef) will be set to the same
+                                            value automatically if one of them is empty and the other is non-empty.
+                                            When namespace is specified in dataSourceRef,
+                                            dataSource isn't set to the same value and must be empty.
+                                            There are three important differences between dataSource and dataSourceRef:
+                                            * While dataSource only allows two specific types of objects, dataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            * While dataSource only allows local objects, dataSourceRef allows objects
+                                              in any namespaces.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          properties:
+                                            apiGroup:
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                Namespace is the namespace of resource being referenced
+                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        resources:
+                                          description: |-
+                                            resources represents the minimum resources the volume should have.
+                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                            that are lower than previous value but must still be higher than capacity recorded in the
+                                            status field of the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: |-
+                                                Limits describes the maximum amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: |-
+                                                Requests describes the minimum amount of compute resources required.
+                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                              type: object
+                                          type: object
+                                        selector:
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          description: |-
+                                            storageClassName is the name of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                          type: string
+                                        volumeAttributesClassName:
+                                          description: |-
+                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                            If specified, the CSI driver will create or update the volume with the attributes defined
+                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                            will be set by the persistentvolume controller if it exists.
+                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                            exists.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                            (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                                          type: string
+                                        volumeMode:
+                                          description: |-
+                                            volumeMode defines what type of volume is required by the claim.
+                                            Value of Filesystem is implied when not included in claim spec.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - spec
+                                  type: object
+                              type: object
+                            fc:
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                lun:
+                                  description: 'lun is Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              description: |-
+                                flexVolume represents a generic volume resource that is
+                                provisioned/attached using an exec based plugin.
+                                Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                              properties:
+                                driver:
+                                  description: driver is the name of the driver to
+                                    use for this volume.
+                                  type: string
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
+                                  type: object
+                                readOnly:
+                                  description: |-
+                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef is Optional: secretRef is reference to the secret object containing
+                                    sensitive information to pass to the plugin scripts. This may be
+                                    empty if no secret object is specified. If the secret object
+                                    contains more than one secret, all secrets are passed to the plugin
+                                    scripts.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              description: |-
+                                flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                              properties:
+                                datasetName:
+                                  description: |-
+                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                    should be considered as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: |-
+                                gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  type: string
+                                partition:
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: |-
+                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              description: |-
+                                gitRepo represents a git repository at a particular revision.
+                                Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                into the Pod's container.
+                              properties:
+                                directory:
+                                  description: |-
+                                    directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                    the subdirectory with the given name.
+                                  type: string
+                                repository:
+                                  description: repository is the URL
+                                  type: string
+                                revision:
+                                  description: revision is the commit hash for the
+                                    specified revision.
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              description: |-
+                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                              properties:
+                                endpoints:
+                                  description: |-
+                                    endpoints is the endpoint name that details Glusterfs topology.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  type: string
+                                path:
+                                  description: |-
+                                    path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              description: |-
+                                hostPath represents a pre-existing file or directory on the host
+                                machine that is directly exposed to the container. This is generally
+                                used for system agents or other privileged things that are allowed
+                                to see the host machine. Most containers will NOT need this.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              properties:
+                                path:
+                                  description: |-
+                                    path of the directory on the host.
+                                    If the path is a symlink, it will follow the link to the real path.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  type: string
+                                type:
+                                  description: |-
+                                    type for HostPath Volume
+                                    Defaults to ""
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            image:
+                              description: |-
+                                image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                                The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            iscsi:
+                              description: |-
+                                iscsi represents an ISCSI Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://examples.k8s.io/volumes/iscsi/README.md
+                              properties:
+                                chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
+                                  type: boolean
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                  type: string
+                                initiatorName:
+                                  description: |-
+                                    initiatorName is the custom iSCSI Initiator Name.
+                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                    <target portal>:<volume name> will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  description: |-
+                                    iscsiInterface is the interface Name that uses an iSCSI transport.
+                                    Defaults to 'default' (tcp).
+                                  type: string
+                                lun:
+                                  description: lun represents iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: |-
+                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  description: |-
+                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
+                                  type: string
+                              required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                              type: object
+                            name:
+                              description: |-
+                                name of the volume.
+                                Must be a DNS_LABEL and unique within the pod.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
+                            persistentVolumeClaim:
+                              description: |-
+                                persistentVolumeClaimVolumeSource represents a reference to a
+                                PersistentVolumeClaim in the same namespace.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                              properties:
+                                claimName:
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: |-
+                                photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                pdID:
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              description: |-
+                                portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                                is on.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    defaultMode are the mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: |-
+                                    sources is the list of volume projections. Each entry in this list
+                                    handles one source.
+                                  items:
+                                    description: |-
+                                      Projection that may be projected along with other supported volume types.
+                                      Exactly one of these fields must be set.
+                                    properties:
+                                      clusterTrustBundle:
+                                        description: |-
+                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                          of ClusterTrustBundle objects in an auto-updating file.
+
+                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                          ClusterTrustBundle objects can either be selected by name, or by the
+                                          combination of signer name and a label selector.
+
+                                          Kubelet performs aggressive normalization of the PEM contents written
+                                          into the pod filesystem.  Esoteric PEM features such as inter-block
+                                          comments and block headers are stripped.  Certificates are deduplicated.
+                                          The ordering of certificates within the file is arbitrary, and Kubelet
+                                          may change the order over time.
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              Select all ClusterTrustBundles that match this label selector.  Only has
+                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                              interpreted as "match nothing".  If set but empty, interpreted as "match
+                                              everything".
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            description: |-
+                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                              with signerName and labelSelector.
+                                            type: string
+                                          optional:
+                                            description: |-
+                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                              aren't available.  If using name, then the named ClusterTrustBundle is
+                                              allowed not to exist.  If using signerName, then the combination of
+                                              signerName and labelSelector is allowed to match zero
+                                              ClusterTrustBundles.
+                                            type: boolean
+                                          path:
+                                            description: Relative path from the volume
+                                              root to write the bundle.
+                                            type: string
+                                          signerName:
+                                            description: |-
+                                              Select all ClusterTrustBundles that match this signer name.
+                                              Mutually-exclusive with name.  The contents of all selected
+                                              ClusterTrustBundles will be unified and deduplicated.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                      configMap:
+                                        description: configMap information about the
+                                          configMap data to project
+                                        properties:
+                                          items:
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              ConfigMap will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the ConfigMap,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name, namespace and uid
+                                                    are supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  description: |-
+                                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                                    between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      secret:
+                                        description: secret information about the
+                                          secret data to project
+                                        properties:
+                                          items:
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              Secret will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the Secret,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
+                                        properties:
+                                          audience:
+                                            description: |-
+                                              audience is the intended audience of the token. A recipient of a token
+                                              must identify itself with an identifier specified in the audience of the
+                                              token, and otherwise should reject the token. The audience defaults to the
+                                              identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: |-
+                                              expirationSeconds is the requested duration of validity of the service
+                                              account token. As the token approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service account token. The kubelet will
+                                              start trying to rotate the token if the token is older than 80 percent of
+                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                              and must be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: |-
+                                              path is the path relative to the mount point of the file to project the
+                                              token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              description: |-
+                                quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                              properties:
+                                group:
+                                  description: |-
+                                    group to map volume access to
+                                    Default is no group
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                  type: boolean
+                                registry:
+                                  description: |-
+                                    registry represents a single or multiple Quobyte Registry services
+                                    specified as a string as host:port pair (multiple entries are separated with commas)
+                                    which acts as the central registry for volumes
+                                  type: string
+                                tenant:
+                                  description: |-
+                                    tenant owning the given Quobyte volume in the Backend
+                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                  type: string
+                                user:
+                                  description: |-
+                                    user to map volume access to
+                                    Defaults to serivceaccount user
+                                  type: string
+                                volume:
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              description: |-
+                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                  type: string
+                                image:
+                                  description: |-
+                                    image is the rados image name.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  description: |-
+                                    keyring is the path to key ring for RBDUser.
+                                    Default is /etc/ceph/keyring.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                                monitors:
+                                  description: |-
+                                    monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  description: |-
+                                    pool is the rados pool name.
+                                    Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef is name of the authentication secret for RBDUser. If provided
+                                    overrides keyring.
+                                    Default is nil.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  description: |-
+                                    user is the rados user name.
+                                    Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                              required:
+                              - image
+                              - monitors
+                              type: object
+                            scaleIO:
+                              description: |-
+                                scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs".
+                                    Default is "xfs".
+                                  type: string
+                                gateway:
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef references to the secret for ScaleIO user and other
+                                    sensitive information. If this is not provided, Login operation will fail.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  description: |-
+                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
+                                  type: string
+                                system:
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: |-
+                                    volumeName is the name of a volume already created in the ScaleIO system
+                                    that is associated with this volume source.
+                                  type: string
+                              required:
+                              - gateway
+                              - secretRef
+                              - system
+                              type: object
+                            secret:
+                              description: |-
+                                secret represents a secret that should populate this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values
+                                    for mode bits. Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the Secret,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
+                                  type: boolean
+                                secretName:
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                  type: string
+                              type: object
+                            storageos:
+                              description: |-
+                                storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef specifies the secret to use for obtaining the StorageOS API
+                                    credentials.  If not specified, default values will be attempted.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  description: |-
+                                    volumeName is the human-readable name of the StorageOS volume.  Volume
+                                    names are only unique within a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: |-
+                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                    namespace is specified then the Pod's namespace will be used.  This allows the
+                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default behaviour.
+                                    Set to "default" if you are not using namespaces within StorageOS.
+                                    Namespaces that do not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: |-
+                                vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                are redirected to the csi.vsphere.vmware.com CSI driver.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
+                                  type: string
+                                volumePath:
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    required:
+                    - containers
+                    type: object
+                type: object
+              type:
+                default: rw
+                description: 'Type of service to forward traffic to. Default: `rw`.'
+                enum:
+                - rw
+                - ro
+                - r
+                type: string
+            required:
+            - cluster
+            - pgbouncer
+            type: object
+          status:
+            description: |-
+              Most recently observed status of the Pooler. This data may not be up to
+              date. Populated by the system. Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              instances:
+                description: The number of pods trying to be scheduled
+                format: int32
+                type: integer
+              secrets:
+                description: The resource version of the config object
+                properties:
+                  clientCA:
+                    description: The client CA secret version
+                    properties:
+                      name:
+                        description: The name of the secret
+                        type: string
+                      version:
+                        description: The ResourceVersion of the secret
+                        type: string
+                    type: object
+                  pgBouncerSecrets:
+                    description: The version of the secrets used by PgBouncer
+                    properties:
+                      authQuery:
+                        description: The auth query secret version
+                        properties:
+                          name:
+                            description: The name of the secret
+                            type: string
+                          version:
+                            description: The ResourceVersion of the secret
+                            type: string
+                        type: object
+                    type: object
+                  serverCA:
+                    description: The server CA secret version
+                    properties:
+                      name:
+                        description: The name of the secret
+                        type: string
+                      version:
+                        description: The ResourceVersion of the secret
+                        type: string
+                    type: object
+                  serverTLS:
+                    description: The server TLS secret version
+                    properties:
+                      name:
+                        description: The name of the secret
+                        type: string
+                      version:
+                        description: The ResourceVersion of the secret
+                        type: string
+                    type: object
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.instances
+        statusReplicasPath: .status.instances
+      status: {}

--- a/config/crd/cnpg/postgresql.cnpg.io_publications.yaml
+++ b/config/crd/cnpg/postgresql.cnpg.io_publications.yaml
@@ -1,0 +1,195 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: publications.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Publication
+    listKind: PublicationList
+    plural: publications
+    singular: publication
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.name
+      name: PG Name
+      type: string
+    - jsonPath: .status.applied
+      name: Applied
+      type: boolean
+    - description: Latest reconciliation message
+      jsonPath: .status.message
+      name: Message
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Publication is the Schema for the publications API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PublicationSpec defines the desired state of Publication
+            properties:
+              cluster:
+                description: The name of the PostgreSQL cluster that identifies the
+                  "publisher"
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              dbname:
+                description: |-
+                  The name of the database where the publication will be installed in
+                  the "publisher" cluster
+                type: string
+                x-kubernetes-validations:
+                - message: dbname is immutable
+                  rule: self == oldSelf
+              name:
+                description: The name of the publication inside PostgreSQL
+                type: string
+                x-kubernetes-validations:
+                - message: name is immutable
+                  rule: self == oldSelf
+              parameters:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Publication parameters part of the `WITH` clause as expected by
+                  PostgreSQL `CREATE PUBLICATION` command
+                type: object
+              publicationReclaimPolicy:
+                default: retain
+                description: The policy for end-of-life maintenance of this publication
+                enum:
+                - delete
+                - retain
+                type: string
+              target:
+                description: Target of the publication as expected by PostgreSQL `CREATE
+                  PUBLICATION` command
+                properties:
+                  allTables:
+                    description: |-
+                      Marks the publication as one that replicates changes for all tables
+                      in the database, including tables created in the future.
+                      Corresponding to `FOR ALL TABLES` in PostgreSQL.
+                    type: boolean
+                    x-kubernetes-validations:
+                    - message: allTables is immutable
+                      rule: self == oldSelf
+                  objects:
+                    description: Just the following schema objects
+                    items:
+                      description: PublicationTargetObject is an object to publish
+                      properties:
+                        table:
+                          description: |-
+                            Specifies a list of tables to add to the publication. Corresponding
+                            to `FOR TABLE` in PostgreSQL.
+                          properties:
+                            columns:
+                              description: The columns to publish
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The table name
+                              type: string
+                            only:
+                              description: Whether to limit to the table only or include
+                                all its descendants
+                              type: boolean
+                            schema:
+                              description: The schema name
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        tablesInSchema:
+                          description: |-
+                            Marks the publication as one that replicates changes for all tables
+                            in the specified list of schemas, including tables created in the
+                            future. Corresponding to `FOR TABLES IN SCHEMA` in PostgreSQL.
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: tablesInSchema and table are mutually exclusive
+                        rule: (has(self.tablesInSchema) && !has(self.table)) || (!has(self.tablesInSchema)
+                          && has(self.table))
+                    maxItems: 100000
+                    type: array
+                    x-kubernetes-validations:
+                    - message: specifying a column list when the publication also
+                        publishes tablesInSchema is not supported
+                      rule: '!(self.exists(o, has(o.table) && has(o.table.columns))
+                        && self.exists(o, has(o.tablesInSchema)))'
+                type: object
+                x-kubernetes-validations:
+                - message: allTables and objects are mutually exclusive
+                  rule: (has(self.allTables) && !has(self.objects)) || (!has(self.allTables)
+                    && has(self.objects))
+            required:
+            - cluster
+            - dbname
+            - name
+            - target
+            type: object
+          status:
+            description: PublicationStatus defines the observed state of Publication
+            properties:
+              applied:
+                description: Applied is true if the publication was reconciled correctly
+                type: boolean
+              message:
+                description: Message is the reconciliation output message
+                type: string
+              observedGeneration:
+                description: |-
+                  A sequence number representing the latest
+                  desired state that was synchronized
+                format: int64
+                type: integer
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/cnpg/postgresql.cnpg.io_scheduledbackups.yaml
+++ b/config/crd/cnpg/postgresql.cnpg.io_scheduledbackups.yaml
@@ -1,0 +1,191 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: scheduledbackups.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: ScheduledBackup
+    listKind: ScheduledBackupList
+    plural: scheduledbackups
+    singular: scheduledbackup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .status.lastScheduleTime
+      name: Last Backup
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ScheduledBackup is the Schema for the scheduledbackups API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the desired behavior of the ScheduledBackup.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              backupOwnerReference:
+                default: none
+                description: |-
+                  Indicates which ownerReference should be put inside the created backup resources.<br />
+                  - none: no owner reference for created backup objects (same behavior as before the field was introduced)<br />
+                  - self: sets the Scheduled backup object as owner of the backup<br />
+                  - cluster: set the cluster as owner of the backup<br />
+                enum:
+                - none
+                - self
+                - cluster
+                type: string
+              cluster:
+                description: The cluster to backup
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              immediate:
+                description: If the first backup has to be immediately start after
+                  creation or not
+                type: boolean
+              method:
+                default: barmanObjectStore
+                description: |-
+                  The backup method to be used, possible options are `barmanObjectStore`,
+                  `volumeSnapshot` or `plugin`. Defaults to: `barmanObjectStore`.
+                enum:
+                - barmanObjectStore
+                - volumeSnapshot
+                - plugin
+                type: string
+              online:
+                description: |-
+                  Whether the default type of backup with volume snapshots is
+                  online/hot (`true`, default) or offline/cold (`false`)
+                  Overrides the default setting specified in the cluster field '.spec.backup.volumeSnapshot.online'
+                type: boolean
+              onlineConfiguration:
+                description: |-
+                  Configuration parameters to control the online/hot backup with volume snapshots
+                  Overrides the default settings specified in the cluster '.backup.volumeSnapshot.onlineConfiguration' stanza
+                properties:
+                  immediateCheckpoint:
+                    description: |-
+                      Control whether the I/O workload for the backup initial checkpoint will
+                      be limited, according to the `checkpoint_completion_target` setting on
+                      the PostgreSQL server. If set to true, an immediate checkpoint will be
+                      used, meaning PostgreSQL will complete the checkpoint as soon as
+                      possible. `false` by default.
+                    type: boolean
+                  waitForArchive:
+                    default: true
+                    description: |-
+                      If false, the function will return immediately after the backup is completed,
+                      without waiting for WAL to be archived.
+                      This behavior is only useful with backup software that independently monitors WAL archiving.
+                      Otherwise, WAL required to make the backup consistent might be missing and make the backup useless.
+                      By default, or when this parameter is true, pg_backup_stop will wait for WAL to be archived when archiving is
+                      enabled.
+                      On a standby, this means that it will wait only when archive_mode = always.
+                      If write activity on the primary is low, it may be useful to run pg_switch_wal on the primary in order to trigger
+                      an immediate segment switch.
+                    type: boolean
+                type: object
+              pluginConfiguration:
+                description: Configuration parameters passed to the plugin managing
+                  this backup
+                properties:
+                  name:
+                    description: Name is the name of the plugin managing this backup
+                    type: string
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Parameters are the configuration parameters passed to the backup
+                      plugin for this backup
+                    type: object
+                required:
+                - name
+                type: object
+              schedule:
+                description: |-
+                  The schedule does not follow the same format used in Kubernetes CronJobs
+                  as it includes an additional seconds specifier,
+                  see https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format
+                type: string
+              suspend:
+                description: If this backup is suspended or not
+                type: boolean
+              target:
+                description: |-
+                  The policy to decide which instance should perform this backup. If empty,
+                  it defaults to `cluster.spec.backup.target`.
+                  Available options are empty string, `primary` and `prefer-standby`.
+                  `primary` to have backups run always on primary instances,
+                  `prefer-standby` to have backups run preferably on the most updated
+                  standby, if available.
+                enum:
+                - primary
+                - prefer-standby
+                type: string
+            required:
+            - cluster
+            - schedule
+            type: object
+          status:
+            description: |-
+              Most recently observed status of the ScheduledBackup. This data may not be up
+              to date. Populated by the system. Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              lastCheckTime:
+                description: The latest time the schedule
+                format: date-time
+                type: string
+              lastScheduleTime:
+                description: Information when was the last time that backup was successfully
+                  scheduled.
+                format: date-time
+                type: string
+              nextScheduleTime:
+                description: Next time we will run a backup
+                format: date-time
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/cnpg/postgresql.cnpg.io_subscriptions.yaml
+++ b/config/crd/cnpg/postgresql.cnpg.io_subscriptions.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: subscriptions.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Subscription
+    listKind: SubscriptionList
+    plural: subscriptions
+    singular: subscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.name
+      name: PG Name
+      type: string
+    - jsonPath: .status.applied
+      name: Applied
+      type: boolean
+    - description: Latest reconciliation message
+      jsonPath: .status.message
+      name: Message
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Subscription is the Schema for the subscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SubscriptionSpec defines the desired state of Subscription
+            properties:
+              cluster:
+                description: The name of the PostgreSQL cluster that identifies the
+                  "subscriber"
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              dbname:
+                description: |-
+                  The name of the database where the publication will be installed in
+                  the "subscriber" cluster
+                type: string
+                x-kubernetes-validations:
+                - message: dbname is immutable
+                  rule: self == oldSelf
+              externalClusterName:
+                description: The name of the external cluster with the publication
+                  ("publisher")
+                type: string
+              name:
+                description: The name of the subscription inside PostgreSQL
+                type: string
+                x-kubernetes-validations:
+                - message: name is immutable
+                  rule: self == oldSelf
+              parameters:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Subscription parameters included in the `WITH` clause of the PostgreSQL
+                  `CREATE SUBSCRIPTION` command. Most parameters cannot be changed
+                  after the subscription is created and will be ignored if modified
+                  later, except for a limited set documented at:
+                  https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET
+                type: object
+              publicationDBName:
+                description: |-
+                  The name of the database containing the publication on the external
+                  cluster. Defaults to the one in the external cluster definition.
+                type: string
+              publicationName:
+                description: |-
+                  The name of the publication inside the PostgreSQL database in the
+                  "publisher"
+                type: string
+              subscriptionReclaimPolicy:
+                default: retain
+                description: The policy for end-of-life maintenance of this subscription
+                enum:
+                - delete
+                - retain
+                type: string
+            required:
+            - cluster
+            - dbname
+            - externalClusterName
+            - name
+            - publicationName
+            type: object
+          status:
+            description: SubscriptionStatus defines the observed state of Subscription
+            properties:
+              applied:
+                description: Applied is true if the subscription was reconciled correctly
+                type: boolean
+              message:
+                description: Message is the reconciliation output message
+                type: string
+              observedGeneration:
+                description: |-
+                  A sequence number representing the latest
+                  desired state that was synchronized
+                format: int64
+                type: integer
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,6 +14,7 @@ rules:
   - get
   - list
   - patch
+  - update
   - watch
 - apiGroups:
   - admissionregistration.k8s.io

--- a/hack/kind/boostrap_kind_with_cnpg.sh
+++ b/hack/kind/boostrap_kind_with_cnpg.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -euxo pipefail
 
+K8S_VERSION=${K8S_VERSION:-v1.32.2}
+
 cd "$(dirname "$0")"
 
 # Create kind cluster
-kind create cluster --config ./kind.yaml 
+kind create cluster --config ./kind.yaml --image "kindest/node:${K8S_VERSION}"
 
 # Install cilium
 helm repo add cilium https://helm.cilium.io/
@@ -19,7 +21,7 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 
 # Install CNPG
 kubectl apply --server-side -f \
-  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.26/releases/cnpg-1.26.0.yaml
+  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.27/releases/cnpg-1.27.0.yaml
 
 # Wait for CNPG manager deployment is ready
 kubectl rollout status deployment/cnpg-controller-manager -n cnpg-system --timeout=180s

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -168,15 +168,13 @@ func (r *BackupReconciler) reconcileRelatedBackupsMetadata(ctx context.Context, 
 	err := r.Get(ctx, client.ObjectKey{Namespace: backup.Namespace, Name: backup.Spec.Cluster.Name}, cluster)
 	// Tolerating non-existing cluster, this only blocks PG version evaluation
 	if err != nil && !apierrors.IsNotFound(err) {
-		logger.Error(err, "Failed to get Cluster for Backup")
-		return err
+		return fmt.Errorf("on reconcileRelatedBackupsMetadata: %w", err)
 	}
 
 	// Get BackupConfig
 	backupConfig, err := v1beta1.GetBackupConfigForBackup(ctx, r.Client, backup)
 	if err != nil {
-		logger.Error(err, "while prefetching secrets data")
-		return err
+		return fmt.Errorf("on reconcileRelatedBackupsMetadata: %w", err)
 	}
 
 	_, err = r.reconcileBackupMetadata(ctx, backup, backupConfig, cluster)

--- a/internal/controller/backupconfig_controller_test.go
+++ b/internal/controller/backupconfig_controller_test.go
@@ -92,7 +92,7 @@ var _ = Describe("BackupConfig Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Add finalizers to simulate the normal reconcile process
-			resource.Finalizers = []string{v1beta1.BackupConfigFinalizerName, v1beta1.BackupConfigSecretProtectionFinalizerName}
+			resource.Finalizers = []string{v1beta1.BackupConfigFinalizerName, v1beta1.BackupConfigSecretFinalizerName}
 			err = k8sClient.Update(ctx, resource)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/backupconfig_controller_test.go
+++ b/internal/controller/backupconfig_controller_test.go
@@ -92,7 +92,7 @@ var _ = Describe("BackupConfig Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Add finalizers to simulate the normal reconcile process
-			resource.Finalizers = []string{v1beta1.BackupConfigFinalizerName, v1beta1.BackupConfigSecretFinalizerName}
+			resource.Finalizers = []string{v1beta1.BackupConfigFinalizerName}
 			err = k8sClient.Update(ctx, resource)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/backupconfig_secrets.go
+++ b/internal/controller/backupconfig_secrets.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2025 YANDEX LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	v1beta1 "github.com/wal-g/cnpg-plugin-wal-g/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// getSecretReferencesFromBackupConfig returns a list of secret references from a BackupConfig
+func getSecretReferencesFromBackupConfig(backupConfig *v1beta1.BackupConfig) []types.NamespacedName {
+	secretRefs := make([]types.NamespacedName, 0)
+
+	// Add S3 storage credentials if they exist
+	if backupConfig.Spec.Storage.S3 != nil {
+		if backupConfig.Spec.Storage.S3.AccessKeyIDRef != nil {
+			secretRefs = append(secretRefs, types.NamespacedName{
+				Namespace: backupConfig.Namespace,
+				Name:      backupConfig.Spec.Storage.S3.AccessKeyIDRef.Name,
+			})
+		}
+
+		if backupConfig.Spec.Storage.S3.AccessKeySecretRef != nil {
+			secretRefs = append(secretRefs, types.NamespacedName{
+				Namespace: backupConfig.Namespace,
+				Name:      backupConfig.Spec.Storage.S3.AccessKeySecretRef.Name,
+			})
+		}
+	}
+
+	// Add encryption secret if it exists
+	if backupConfig.Spec.Encryption.Method != "" && backupConfig.Spec.Encryption.Method != "none" {
+		secretRefs = append(secretRefs, types.NamespacedName{
+			Namespace: backupConfig.Namespace,
+			Name:      v1beta1.GetBackupConfigEncryptionSecretName(backupConfig),
+		})
+	}
+
+	return secretRefs
+}
+
+func isSecretReferencedByAnyBackupConfig(
+	ctx context.Context,
+	c client.Client,
+	secret *corev1.Secret,
+) (bool, error) {
+	// List all BackupConfigs in the same namespace
+	backupConfigList := &v1beta1.BackupConfigList{}
+	if err := c.List(ctx, backupConfigList, &client.ListOptions{Namespace: secret.Namespace}); err != nil {
+		return false, fmt.Errorf("failed to list BackupConfigs: %w", err)
+	}
+
+	// Check if any BackupConfig references this secret
+	for i := range backupConfigList.Items {
+		backupConfig := &backupConfigList.Items[i]
+		secretRefs := getSecretReferencesFromBackupConfig(backupConfig)
+
+		for _, ref := range secretRefs {
+			if ref.Name == secret.Name && ref.Namespace == secret.Namespace {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// setFinalizerOnSecret sets the BackupConfigSecretFinalizerName finalizer on a secret
+func setFinalizerOnSecret(
+	ctx context.Context,
+	c client.Client,
+	secretRef types.NamespacedName,
+) error {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, secretRef, secret); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	if containsString(secret.Finalizers, v1beta1.BackupConfigSecretFinalizerName) {
+		return nil
+	}
+
+	secret.Finalizers = append(secret.Finalizers, v1beta1.BackupConfigSecretFinalizerName)
+	return c.Update(ctx, secret)
+}
+
+// removeFinalizerFromSecret removes the BackupConfigSecretFinalizerName finalizer from a secret
+// if it's no longer referenced by any BackupConfig
+func removeFinalizerFromSecret(
+	ctx context.Context,
+	c client.Client,
+	secret *corev1.Secret,
+) error {
+	if !containsString(secret.Finalizers, v1beta1.BackupConfigSecretFinalizerName) {
+		return nil
+	}
+
+	secret.Finalizers = removeString(secret.Finalizers, v1beta1.BackupConfigSecretFinalizerName)
+	return c.Update(ctx, secret)
+}

--- a/internal/controller/secret_reconciler.go
+++ b/internal/controller/secret_reconciler.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 YANDEX LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	v1beta1 "github.com/wal-g/cnpg-plugin-wal-g/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SecretReconciler reconciles Secret objects to protect them from accidental deletion
+// when they are referenced by BackupConfig resources
+type SecretReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update;patch
+
+// Reconcile handles Secret resource events
+func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+	logger.V(1).Info("Running Reconcile for Secret", "secret", req.NamespacedName)
+
+	// Get the Secret
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, req.NamespacedName, secret); err != nil {
+		// The Secret resource may have been deleted
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// If the Secret is being deleted and has our finalizer
+	if !secret.DeletionTimestamp.IsZero() && containsString(secret.Finalizers, v1beta1.BackupConfigSecretFinalizerName) {
+		isReferenced, err := isSecretReferencedByAnyBackupConfig(ctx, r.Client, secret)
+		if err != nil {
+			logger.Error(err, "Failed to check if Secret is referenced by any BackupConfig")
+			return ctrl.Result{}, err
+		}
+
+		// If the Secret is still referenced, we can't remove the finalizer
+		if isReferenced {
+			logger.Info(
+				"Secret is still referenced by a BackupConfig, cannot remove finalizer, retrying in 1 minute", "secret", secret.Name,
+			)
+			// Need requeue, because BackupConfig deletion will not trigger related Secret reconcilers by default
+			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+		}
+
+		if err := removeFinalizerFromSecret(ctx, r.Client, secret); err != nil {
+			return ctrl.Result{}, fmt.Errorf("while removing finalizer from secret %s: %w", secret.Name, err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	isReferenced, err := isSecretReferencedByAnyBackupConfig(ctx, r.Client, secret)
+	if err != nil {
+		logger.Error(err, "Failed to check if Secret is referenced by any BackupConfig")
+		return ctrl.Result{}, err
+	}
+
+	// If the Secret is not referenced and has our finalizer, remove it
+	// If the Secret IS referenced - BackupConfig reconciler should add finalizer on Secret
+	if !isReferenced && containsString(secret.Finalizers, v1beta1.BackupConfigSecretFinalizerName) {
+		logger.Info("Removing finalizer from Secret", "secret", secret.Name)
+		if err := removeFinalizerFromSecret(ctx, r.Client, secret); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).
+		Named("secret-protection").
+		Complete(r)
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -62,12 +63,17 @@ var _ = BeforeSuite(func() {
 	var err error
 	err = v1beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
+	err = cnpgv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "config", "crd", "cnpg"),
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 

--- a/internal/operator/manager.go
+++ b/internal/operator/manager.go
@@ -91,7 +91,7 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-// nolint:gocyclo
+// nolint:gocyclo,funlen
 func Start(ctx context.Context) error {
 	var tlsOpts []func(*tls.Config)
 

--- a/internal/operator/manager.go
+++ b/internal/operator/manager.go
@@ -236,7 +236,7 @@ func Start(ctx context.Context) error {
 	if err = (&controller.BackupConfigReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, backupDeletionController); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BackupConfigReconciler")
 		return err
 	}

--- a/internal/operator/manager.go
+++ b/internal/operator/manager.go
@@ -261,6 +261,15 @@ func Start(ctx context.Context) error {
 		return err
 	}
 
+	// Register the SecretReconciler
+	if err = (&controller.SecretReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "SecretReconciler")
+		return err
+	}
+
 	// nolint:goconst
 	kubeClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: scheme})
 	if err != nil {

--- a/internal/util/walg/backups.go
+++ b/internal/util/walg/backups.go
@@ -206,7 +206,7 @@ func DeleteAllBackupsAndWALsInStorage(
 	backupConfig *v1beta1.BackupConfigWithSecrets,
 	pgMajorVersion int,
 ) (*cmd.RunResult, error) {
-	return cmd.New("wal-g", "delete", "everything", "--confirm").
+	return cmd.New("wal-g", "delete", "everything", "FORCE", "--confirm").
 		WithContext(ctx).
 		WithEnv(NewConfigFromBackupConfig(backupConfig, pgMajorVersion).ToEnvMap()).
 		Run()

--- a/internal/util/walg/backups.go
+++ b/internal/util/walg/backups.go
@@ -201,6 +201,17 @@ func DeleteBackup(
 	return result, err
 }
 
+func DeleteAllBackupsAndWALsInStorage(
+	ctx context.Context,
+	backupConfig *v1beta1.BackupConfigWithSecrets,
+	pgMajorVersion int,
+) (*cmd.RunResult, error) {
+	return cmd.New("wal-g", "delete", "everything", "--confirm").
+		WithContext(ctx).
+		WithEnv(NewConfigFromBackupConfig(backupConfig, pgMajorVersion).ToEnvMap()).
+		Run()
+}
+
 // GetDependentBackups returns a list of backups that depend on the current backup.
 // This is determined by analyzing backup names, where delta backups include their base backup's WAL ID.
 // For example:


### PR DESCRIPTION
## Description

This PR implements protection for Secrets referenced by BackupConfig resources and enhances the backup deletion process. It adds a new finalizer to prevent accidental deletion of Secrets while they are still in use by BackupConfig resources. Additionally, it refactors the backup deletion controller to handle both Backup and BackupConfig resources in a more structured way.

Key changes:
- Added a new finalizer `BackupConfigSecretFinalizerName` to protect Secrets from accidental deletion
- Created a new SecretReconciler controller to manage Secret protection
- Refactored BackupDeletionController to handle both Backup and BackupConfig resources
- Added support for complete storage cleanup when a BackupConfig is deleted
- Improved error handling in backup controllers
- Added "update" permission to RBAC roles


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
