### PR TITLE
feat: tarDisableFsync and tarSizeThreshold options

### DIFF
--- a/api/v1beta1/backupconfig_types.go
+++ b/api/v1beta1/backupconfig_types.go
@@ -112,6 +112,12 @@ type BackupConfigSpec struct {
 	// Determines how many delta backups can be between full backups. Defaults to 0.
 	DeltaMaxSteps int `json:"deltaMaxSteps,omitempty"`
 
+	// Disable calling fsync after writing files when extracting tar files. Default: false.
+	TarDisableFsync bool `json:"tarDisableFsync,omitempty"`
+
+	// Threshold in bytes is size of one backup bundle. Default: 1073741823.
+	TarSizeThreshold *int64 `json:"tarSizeThreshold,omitempty"`
+
 	// Backups retention configuration
 	Retention BackupRetentionConfig `json:"retention,omitempty"`
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -112,6 +112,11 @@ func (in *BackupConfigSpec) DeepCopyInto(out *BackupConfigSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.TarSizeThreshold != nil {
+		in, out := &in.TarSizeThreshold, &out.TarSizeThreshold
+		*out = new(int64)
+		**out = **in
+	}
 	out.Retention = in.Retention
 	in.Storage.DeepCopyInto(&out.Storage)
 	in.Resources.DeepCopyInto(&out.Resources)

--- a/chart/templates/crd/cnpg-extensions.yandex.cloud_backupconfigs.yaml
+++ b/chart/templates/crd/cnpg-extensions.yandex.cloud_backupconfigs.yaml
@@ -275,6 +275,15 @@ spec:
                 required:
                 - type
                 type: object
+              tarDisableFsync:
+                description: 'Disable calling fsync after writing files when extracting
+                  tar files. Default: false.'
+                type: boolean
+              tarSizeThreshold:
+                description: 'Threshold in bytes is size of one backup bundle. Default:
+                  1073741823.'
+                format: int64
+                type: integer
               uploadConcurrency:
                 description: How many concurrency streams to use during backup uploading.
                   Default value is evaluated at runtime

--- a/config/crd/bases/cnpg-extensions.yandex.cloud_backupconfigs.yaml
+++ b/config/crd/bases/cnpg-extensions.yandex.cloud_backupconfigs.yaml
@@ -275,6 +275,15 @@ spec:
                 required:
                 - type
                 type: object
+              tarDisableFsync:
+                description: 'Disable calling fsync after writing files when extracting
+                  tar files. Default: false.'
+                type: boolean
+              tarSizeThreshold:
+                description: 'Threshold in bytes is size of one backup bundle. Default:
+                  1073741823.'
+                format: int64
+                type: integer
               uploadConcurrency:
                 description: How many concurrency streams to use during backup uploading.
                   Default value is evaluated at runtime

--- a/internal/util/walg/config.go
+++ b/internal/util/walg/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	WalgS3CACertFile                  string `json:"WALG_S3_CA_CERT_FILE,omitempty"`
 	WalgS3StorageClass                string `json:"WALG_S3_STORAGE_CLASS,omitempty"`
 	WalgTarDisableFsync               string `json:"WALG_TAR_DISABLE_FSYNC,omitempty"`
+	WalgTarSizeThreshold              int64  `json:"WALG_TAR_SIZE_THRESHOLD,omitempty"`
 	WalgUploadConcurrency             int    `json:"WALG_UPLOAD_CONCURRENCY,omitempty"`
 	WalgUploadDiskConcurrency         int    `json:"WALG_UPLOAD_DISK_CONCURRENCY,omitempty"`
 }
@@ -124,6 +125,7 @@ func NewConfigFromBackupConfig(backupConfig *v1beta1.BackupConfigWithSecrets, pg
 	}
 	config.WalgDeltaMaxSteps = backupConfig.Spec.DeltaMaxSteps
 	config.WalgDownloadFileRetries = backupConfig.Spec.DownloadFileRetries
+	config.WalgTarDisableFsync = strconv.FormatBool(backupConfig.Spec.TarDisableFsync)
 
 	if backupConfig.Spec.DownloadConcurrency != nil {
 		config.WalgDownloadConcurrency = *backupConfig.Spec.DownloadConcurrency
@@ -139,6 +141,9 @@ func NewConfigFromBackupConfig(backupConfig *v1beta1.BackupConfigWithSecrets, pg
 	}
 	if backupConfig.Spec.UploadDiskConcurrency != nil {
 		config.WalgUploadDiskConcurrency = *backupConfig.Spec.UploadDiskConcurrency
+	}
+	if backupConfig.Spec.TarSizeThreshold != nil {
+		config.WalgTarSizeThreshold = *backupConfig.Spec.TarSizeThreshold
 	}
 	return &config
 }
@@ -198,7 +203,7 @@ func (c *Config) ToEnvMap() map[string]string {
 		}
 
 		switch fieldValueKind {
-		case reflect.Int:
+		case reflect.Int, reflect.Int64:
 			fieldValue = strconv.FormatInt(val.Field(i).Int(), 10)
 		case reflect.String:
 			fieldValue = val.Field(i).String()


### PR DESCRIPTION
## Description

This PR makes possible to redefine wal-g options:
- WALG_TAR_DISABLE_FSYNC
- WALG_TAR_SIZE_THRESHOLD

For large databases, it makes sense to adjust the default values.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
