### PR TITLE
Allow disabling S3 storage cleanup for operator

### DIFF
--- a/api/v1beta1/backupconfig_types.go
+++ b/api/v1beta1/backupconfig_types.go
@@ -180,6 +180,20 @@ type BackupEncryptionConfig struct {
 }
 
 type BackupRetentionConfig struct {
+	// Whether to disable S3 storage cleanup on BackupConfig deletion.
+	// Useful when managing storage retention by S3 lifecycle policies.
+	// When true, the operator will skip storage cleanup when BackupConfig is deleted.
+	// +kubebuilder:default:=false
+	// +optional
+	IgnoreForBackupConfigDeletion bool `json:"ignoreForBackupConfigDeletion,omitempty"`
+
+	// Whether to disable S3 storage cleanup on individual Backup resource deletion.
+	// Useful when managing storage retention by S3 lifecycle policies.
+	// When true, the operator will skip storage cleanup when individual Backup resources are deleted.
+	// +kubebuilder:default:=false
+	// +optional
+	IgnoreForBackupDeletion bool `json:"ignoreForBackupDeletion,omitempty"`
+
 	// Whether to ignore manually created backups in retention policy
 	//
 	// IMPORTANT: Automatically created backups should have OwnerReference with

--- a/chart/templates/crd/cnpg-extensions.yandex.cloud_backupconfigs.yaml
+++ b/chart/templates/crd/cnpg-extensions.yandex.cloud_backupconfigs.yaml
@@ -147,6 +147,20 @@ spec:
                       If not specified - backups will not be deleted automatically
                     pattern: ^[1-9][0-9]*[dwmh]$
                     type: string
+                  ignoreForBackupConfigDeletion:
+                    default: false
+                    description: |-
+                      Whether to disable S3 storage cleanup on BackupConfig deletion.
+                      Useful when managing storage retention by S3 lifecycle policies.
+                      When true, the operator will skip storage cleanup when BackupConfig is deleted.
+                    type: boolean
+                  ignoreForBackupDeletion:
+                    default: false
+                    description: |-
+                      Whether to disable S3 storage cleanup on individual Backup resource deletion.
+                      Useful when managing storage retention by S3 lifecycle policies.
+                      When true, the operator will skip storage cleanup when individual Backup resources are deleted.
+                    type: boolean
                   ignoreForManualBackups:
                     default: false
                     description: |-

--- a/config/crd/bases/cnpg-extensions.yandex.cloud_backupconfigs.yaml
+++ b/config/crd/bases/cnpg-extensions.yandex.cloud_backupconfigs.yaml
@@ -147,6 +147,20 @@ spec:
                       If not specified - backups will not be deleted automatically
                     pattern: ^[1-9][0-9]*[dwmh]$
                     type: string
+                  ignoreForBackupConfigDeletion:
+                    default: false
+                    description: |-
+                      Whether to disable S3 storage cleanup on BackupConfig deletion.
+                      Useful when managing storage retention by S3 lifecycle policies.
+                      When true, the operator will skip storage cleanup when BackupConfig is deleted.
+                    type: boolean
+                  ignoreForBackupDeletion:
+                    default: false
+                    description: |-
+                      Whether to disable S3 storage cleanup on individual Backup resource deletion.
+                      Useful when managing storage retention by S3 lifecycle policies.
+                      When true, the operator will skip storage cleanup when individual Backup resources are deleted.
+                    type: boolean
                   ignoreForManualBackups:
                     default: false
                     description: |-


### PR DESCRIPTION

## Description

Implement .spec.retention.ignoreForBackupConfigDeletion and .spec.retention.ignoreForBackupDeletion for BackupConfig.

This will allow to manage storage retention by S3 lifecycle policies and do not use operator for deleting anything from storage.

This will also protect from cases when accidential deletion for BackupConfig resources leads to removed all backups data in storage.

Fixes #40 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
