### PR TITLE
Add WALG_PREVENT_WAL_OVERWRITE true by default for wal-g parameters

### DIFF
--- a/internal/util/walg/config.go
+++ b/internal/util/walg/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	WalgNetworkRateLimit              int    `json:"WALG_NETWORK_RATE_LIMIT,omitempty"`
 	WalgPgpKeyPath                    string `json:"WALG_PGP_KEY_PATH,omitempty"`
 	WalgPrefetchDir                   string `json:"WALG_PREFETCH_DIR,omitempty"`
+	WalgPreventWalOverwrite           string `json:"WALG_PREVENT_WAL_OVERWRITE,omitempty"`
 	WalgS3CACertFile                  string `json:"WALG_S3_CA_CERT_FILE,omitempty"`
 	WalgS3StorageClass                string `json:"WALG_S3_STORAGE_CLASS,omitempty"`
 	WalgTarDisableFsync               string `json:"WALG_TAR_DISABLE_FSYNC,omitempty"`
@@ -85,6 +86,7 @@ func NewConfigWithDefaults() Config {
 		WalgTarDisableFsync:               "False",
 		WalgUploadConcurrency:             16,
 		WalgUploadDiskConcurrency:         8,
+		WalgPreventWalOverwrite:           "True",
 	}
 }
 


### PR DESCRIPTION
## Description

This prevents from overriding WAL files in storage when ex. 2 clusters use the same storage by mistake

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
