### PR TITLE
Rebrand plugin from Yandex Extensions to WAL-G & Add Metrics Support

### DIFF
--- a/internal/common/plugin_config.go
+++ b/internal/common/plugin_config.go
@@ -48,7 +48,7 @@ func GetPluginConfigFromCluster(cluster *cnpgv1.Cluster) *cnpgv1.PluginConfigura
 	}
 
 	pluginConfig, ok := lo.Find(cluster.Spec.Plugins, func(c cnpgv1.PluginConfiguration) bool {
-		return c.Name == PluginName
+		return c.Name == PluginNameDeprecated
 	})
 
 	if !ok {

--- a/internal/common/plugin_metadata.go
+++ b/internal/common/plugin_metadata.go
@@ -23,13 +23,14 @@ import (
 
 // PluginName is the name of the plugin from the instance manager
 // Point-of-view
-const PluginName = "cnpg-extensions.yandex.cloud"
+const PluginNameDeprecated = "cnpg-extensions.yandex.cloud" // DEPRECATED: Kept for backward compatibility with existing public API
+const PluginName = "cnpg-plugin-wal-g"
 
 // PluginMetadata is the metadata of this plugin.
 var PluginMetadata = identity.GetPluginMetadataResponse{
-	Name:          PluginName,
+	Name:          PluginNameDeprecated, // Keeping for backward compatibility with user manifests
 	Version:       version.GetVersion(),
-	DisplayName:   "CNPGYandexExtensions",
+	DisplayName:   "CNPG Plugin WAL-G",
 	ProjectUrl:    "https://github.com/wal-g/cnpg-plugin-wal-g",
 	RepositoryUrl: "https://github.com/wal-g/cnpg-plugin-wal-g",
 	License:       "APACHE 2.0",

--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -73,7 +73,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Skip backups not managed by plugin
 	if backup.Spec.PluginConfiguration == nil ||
-		backup.Spec.PluginConfiguration.Name != common.PluginName ||
+		backup.Spec.PluginConfiguration.Name != common.PluginNameDeprecated ||
 		backup.Spec.Method != cnpgv1.BackupMethodPlugin {
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -122,7 +122,7 @@ func createTestCluster(name, namespace string) *cnpgv1.Cluster {
 			ImageName: "ghcr.io/cloudnative-pg/postgresql:14.0",
 			Plugins: []cnpgv1.PluginConfiguration{
 				{
-					Name: common.PluginName,
+					Name: common.PluginNameDeprecated,
 					Parameters: map[string]string{
 						"backupConfig": "test-backupconfig",
 					},
@@ -151,7 +151,7 @@ func createTestBackup(name, namespace, clusterName string, backupID string, with
 			},
 			Method: "plugin",
 			PluginConfiguration: &cnpgv1.BackupPluginConfiguration{
-				Name: common.PluginName,
+				Name: common.PluginNameDeprecated,
 			},
 		},
 		Status: cnpgv1.BackupStatus{

--- a/internal/controller/configmap_reconciler.go
+++ b/internal/controller/configmap_reconciler.go
@@ -61,10 +61,10 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// If the ConfigMap is still referenced, we can't remove the finalizer
 		if isReferenced {
 			logger.Info(
-				"ConfigMap is still referenced by a BackupConfig, cannot remove finalizer, retrying in 1 minute", "configmap", configmap.Name,
+				"ConfigMap is still referenced by a BackupConfig, cannot remove finalizer, retrying in 30 seconds", "configmap", configmap.Name,
 			)
 			// Need requeue, because BackupConfig deletion will not trigger related ConfigMap reconcilers by default
-			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 
 		// Remove finalizer and update ConfigMap, if it is needed

--- a/internal/controller/secret_reconciler.go
+++ b/internal/controller/secret_reconciler.go
@@ -62,10 +62,10 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// If the Secret is still referenced, we can't remove the finalizer
 		if isReferenced {
 			logger.Info(
-				"Secret is still referenced by a BackupConfig, cannot remove finalizer, retrying in 1 minute", "secret", secret.Name,
+				"Secret is still referenced by a BackupConfig, cannot remove finalizer, retrying in 30 seconds", "secret", secret.Name,
 			)
 			// Need requeue, because BackupConfig deletion will not trigger related Secret reconcilers by default
-			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 
 		// Remove finalizer and update Secret, if it is needed

--- a/internal/instance/manager.go
+++ b/internal/instance/manager.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 var (
@@ -94,6 +95,9 @@ func Start(ctx context.Context) error {
 					&cnpgv1.Backup{},
 				},
 			},
+		},
+		Metrics: server.Options{
+			BindAddress: "0", // Disabling metrics server by default
 		},
 	}
 

--- a/internal/instance/plugin.go
+++ b/internal/instance/plugin.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cloudnative-pg/cnpg-i-machinery/pkg/pluginhelper/http"
 	"github.com/cloudnative-pg/cnpg-i/pkg/backup"
+	"github.com/cloudnative-pg/cnpg-i/pkg/metrics"
 	restore "github.com/cloudnative-pg/cnpg-i/pkg/restore/job"
 	"github.com/cloudnative-pg/cnpg-i/pkg/wal"
 	"google.golang.org/grpc"
@@ -46,6 +47,9 @@ func (c *CNPGI) Start(ctx context.Context) error {
 			Client: c.Client,
 		})
 		restore.RegisterRestoreJobHooksServer(server, RestoreJobHooksImpl{
+			Client: c.Client,
+		})
+		metrics.RegisterMetricsServer(server, MetricsServerImplementation{
 			Client: c.Client,
 		})
 		return nil

--- a/internal/instance/plugin_identity.go
+++ b/internal/instance/plugin_identity.go
@@ -67,6 +67,13 @@ func (i IdentityImplementation) GetPluginCapabilities(
 					},
 				},
 			},
+			{
+				Type: &identity.PluginCapability_Service_{
+					Service: &identity.PluginCapability_Service{
+						Type: identity.PluginCapability_Service_TYPE_METRICS,
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/internal/instance/plugin_metrics.go
+++ b/internal/instance/plugin_metrics.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2025 YANDEX LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cloudnative-pg/cnpg-i/pkg/metrics"
+	"github.com/wal-g/cnpg-plugin-wal-g/api/v1beta1"
+	"github.com/wal-g/cnpg-plugin-wal-g/internal/common"
+)
+
+// Sanitize the plugin name to be a valid Prometheus metric namespace
+var metricsDomain = strings.NewReplacer(".", "_", "-", "_").Replace(common.PluginName)
+
+type MetricsServerImplementation struct {
+	// important the client should be one with a underlying cache
+	Client client.Client
+	metrics.UnimplementedMetricsServer
+}
+
+func buildFqName(name string) string {
+	// Build the fully qualified name for the metric
+	return fmt.Sprintf("%s_%s", metricsDomain, strings.NewReplacer(".", "_", "-", "_").Replace(name))
+}
+
+var (
+	firstRecoverabilityPointMetricName     = buildFqName("first_recoverability_point")
+	lastAvailableBackupTimestampMetricName = buildFqName("last_available_backup_timestamp")
+	lastFailedBackupTimestampMetricName    = buildFqName("last_failed_backup_timestamp")
+	lastArchivedWALTimestampMetricName     = buildFqName("last_archived_wal_timestamp")
+	totalWALS3UsageBytesMetricName         = buildFqName("total_wal_s3_usage_bytes")
+	totalBackupsS3UsageBytesMetricName     = buildFqName("total_backups_s3_usage_bytes")
+	S3ReadAvailabilityMetricName           = buildFqName("s3_read_availability")
+	S3WriteAvailabilityMetricName          = buildFqName("s3_write_availability")
+)
+
+func (m MetricsServerImplementation) GetCapabilities(
+	ctx context.Context,
+	_ *metrics.MetricsCapabilitiesRequest,
+) (*metrics.MetricsCapabilitiesResult, error) {
+	return &metrics.MetricsCapabilitiesResult{
+		Capabilities: []*metrics.MetricsCapability{
+			{
+				Type: &metrics.MetricsCapability_Rpc{
+					Rpc: &metrics.MetricsCapability_RPC{
+						Type: metrics.MetricsCapability_RPC_TYPE_METRICS,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (m MetricsServerImplementation) Define(
+	ctx context.Context,
+	_ *metrics.DefineMetricsRequest,
+) (*metrics.DefineMetricsResult, error) {
+	return &metrics.DefineMetricsResult{
+		Metrics: []*metrics.Metric{
+			{
+				FqName:    firstRecoverabilityPointMetricName,
+				Help:      "The first point of recoverability for the cluster as a unix timestamp",
+				ValueType: &metrics.MetricType{Type: metrics.MetricType_TYPE_GAUGE},
+			},
+			{
+				FqName:    lastAvailableBackupTimestampMetricName,
+				Help:      "The last available backup as a unix timestamp",
+				ValueType: &metrics.MetricType{Type: metrics.MetricType_TYPE_GAUGE},
+			},
+			{
+				FqName:    lastFailedBackupTimestampMetricName,
+				Help:      "The last failed backup as a unix timestamp",
+				ValueType: &metrics.MetricType{Type: metrics.MetricType_TYPE_GAUGE},
+			},
+			{
+				FqName:    lastArchivedWALTimestampMetricName,
+				Help:      "The last failed backup as a unix timestamp",
+				ValueType: &metrics.MetricType{Type: metrics.MetricType_TYPE_GAUGE},
+			},
+			{
+				FqName:    totalWALS3UsageBytesMetricName,
+				Help:      "The last failed backup as a unix timestamp",
+				ValueType: &metrics.MetricType{Type: metrics.MetricType_TYPE_GAUGE},
+			},
+			{
+				FqName:    totalBackupsS3UsageBytesMetricName,
+				Help:      "The last failed backup as a unix timestamp",
+				ValueType: &metrics.MetricType{Type: metrics.MetricType_TYPE_GAUGE},
+			},
+		},
+	}, nil
+}
+
+func (m MetricsServerImplementation) Collect(
+	ctx context.Context,
+	req *metrics.CollectMetricsRequest,
+) (*metrics.CollectMetricsResult, error) {
+	cluster, err := common.CnpgClusterFromJSON(req.ClusterDefinition)
+	if err != nil {
+		return nil, fmt.Errorf("while creating configuration from cluster definition: %w", err)
+	}
+
+	backupConfig, err := v1beta1.GetBackupConfigForCluster(ctx, m.Client, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch BackupConfig object: %w", err)
+	}
+
+	var firstRecoverabilityPointTS float64 = 0
+	if backupConfig.Status.FirstRecoverabilityPoint != nil {
+		firstRecoverabilityPointTS = float64(backupConfig.Status.FirstRecoverabilityPoint.Time.Unix())
+	}
+	var lastSuccessfulBackupTS float64 = 0
+	if backupConfig.Status.LastSuccessfulBackup != nil {
+		lastSuccessfulBackupTS = float64(backupConfig.Status.FirstRecoverabilityPoint.Time.Unix())
+	}
+	var lastFailedBackupTS float64 = 0
+	if backupConfig.Status.LastFailedBackup != nil {
+		lastFailedBackupTS = float64(backupConfig.Status.LastFailedBackup.Time.Unix())
+	}
+	var totalWALS3UsageBytes float64 = 0
+	if backupConfig.Status.ConsumedStorage.WALBytes != nil {
+		totalWALS3UsageBytes = float64(*backupConfig.Status.ConsumedStorage.WALBytes)
+	}
+	var totalBackupS3UsageBytes float64 = 0
+	if backupConfig.Status.ConsumedStorage.BackupsBytes != nil {
+		totalBackupS3UsageBytes = float64(*backupConfig.Status.ConsumedStorage.BackupsBytes)
+	}
+
+	return &metrics.CollectMetricsResult{
+		Metrics: []*metrics.CollectMetric{
+			{
+				FqName: firstRecoverabilityPointMetricName,
+				Value:  firstRecoverabilityPointTS,
+			},
+			{
+				FqName: lastAvailableBackupTimestampMetricName,
+				Value:  lastSuccessfulBackupTS,
+			},
+			{
+				FqName: lastFailedBackupTimestampMetricName,
+				Value:  lastFailedBackupTS,
+			},
+			{
+				FqName: lastArchivedWALTimestampMetricName,
+				Value:  0, // TODO: fixme
+			},
+			{
+				FqName: totalWALS3UsageBytesMetricName,
+				Value:  totalWALS3UsageBytes,
+			},
+			{
+				FqName: totalBackupsS3UsageBytesMetricName,
+				Value:  totalBackupS3UsageBytes,
+			},
+		},
+	}, nil
+}

--- a/internal/instance/plugin_metrics.go
+++ b/internal/instance/plugin_metrics.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cloudnative-pg/cnpg-i/pkg/metrics"
@@ -49,8 +51,8 @@ var (
 	lastArchivedWALTimestampMetricName     = buildFqName("last_archived_wal_timestamp")
 	totalWALS3UsageBytesMetricName         = buildFqName("total_wal_s3_usage_bytes")
 	totalBackupsS3UsageBytesMetricName     = buildFqName("total_backups_s3_usage_bytes")
-	S3ReadAvailabilityMetricName           = buildFqName("s3_read_availability")
-	S3WriteAvailabilityMetricName          = buildFqName("s3_write_availability")
+	s3ReadAvailabilityMetricName           = buildFqName("s3_read_availability")
+	s3WriteAvailabilityMetricName          = buildFqName("s3_write_availability")
 )
 
 func (m MetricsServerImplementation) GetCapabilities(
@@ -93,17 +95,27 @@ func (m MetricsServerImplementation) Define(
 			},
 			{
 				FqName:    lastArchivedWALTimestampMetricName,
-				Help:      "The last failed backup as a unix timestamp",
+				Help:      "The last successfully archived WAL as a unix timestamp",
 				ValueType: &metrics.MetricType{Type: metrics.MetricType_TYPE_GAUGE},
 			},
 			{
 				FqName:    totalWALS3UsageBytesMetricName,
-				Help:      "The last failed backup as a unix timestamp",
+				Help:      "Total space consumed in S3 by WAL archives in bytes",
 				ValueType: &metrics.MetricType{Type: metrics.MetricType_TYPE_GAUGE},
 			},
 			{
 				FqName:    totalBackupsS3UsageBytesMetricName,
-				Help:      "The last failed backup as a unix timestamp",
+				Help:      "Total space consumed in S3 by basebackups in bytes",
+				ValueType: &metrics.MetricType{Type: metrics.MetricType_TYPE_GAUGE},
+			},
+			{
+				FqName:    s3ReadAvailabilityMetricName,
+				Help:      "Remote object storage read availability (0 meaning false, 1 - true)",
+				ValueType: &metrics.MetricType{Type: metrics.MetricType_TYPE_GAUGE},
+			},
+			{
+				FqName:    s3WriteAvailabilityMetricName,
+				Help:      "Remote object storage write availability (0 meaning false, 1 - true)",
 				ValueType: &metrics.MetricType{Type: metrics.MetricType_TYPE_GAUGE},
 			},
 		},
@@ -124,25 +136,46 @@ func (m MetricsServerImplementation) Collect(
 		return nil, fmt.Errorf("failed to fetch BackupConfig object: %w", err)
 	}
 
-	var firstRecoverabilityPointTS float64 = 0
+	var firstRecoverabilityPointTS float64
 	if backupConfig.Status.FirstRecoverabilityPoint != nil {
-		firstRecoverabilityPointTS = float64(backupConfig.Status.FirstRecoverabilityPoint.Time.Unix())
+		firstRecoverabilityPointTS = float64(backupConfig.Status.FirstRecoverabilityPoint.Unix())
 	}
-	var lastSuccessfulBackupTS float64 = 0
+	var lastSuccessfulBackupTS float64
 	if backupConfig.Status.LastSuccessfulBackup != nil {
-		lastSuccessfulBackupTS = float64(backupConfig.Status.FirstRecoverabilityPoint.Time.Unix())
+		lastSuccessfulBackupTS = float64(backupConfig.Status.FirstRecoverabilityPoint.Unix())
 	}
-	var lastFailedBackupTS float64 = 0
+	var lastFailedBackupTS float64
 	if backupConfig.Status.LastFailedBackup != nil {
-		lastFailedBackupTS = float64(backupConfig.Status.LastFailedBackup.Time.Unix())
+		lastFailedBackupTS = float64(backupConfig.Status.LastFailedBackup.Unix())
 	}
-	var totalWALS3UsageBytes float64 = 0
+
+	var lastArchivedWALTimeTS float64
+	walTime := GetLastArchivedWALTime()
+	if walTime != nil {
+		lastArchivedWALTimeTS = float64(walTime.Unix())
+	}
+
+	var totalWALS3UsageBytes float64
 	if backupConfig.Status.ConsumedStorage.WALBytes != nil {
 		totalWALS3UsageBytes = float64(*backupConfig.Status.ConsumedStorage.WALBytes)
 	}
-	var totalBackupS3UsageBytes float64 = 0
+	var totalBackupS3UsageBytes float64
 	if backupConfig.Status.ConsumedStorage.BackupsBytes != nil {
 		totalBackupS3UsageBytes = float64(*backupConfig.Status.ConsumedStorage.BackupsBytes)
+	}
+
+	var s3ReadAvailability float64
+	if cond := meta.FindStatusCondition(backupConfig.Status.Conditions, v1beta1.ConditionTypeStorageReadable); cond != nil {
+		if cond.Status == v1.ConditionTrue {
+			s3ReadAvailability = 1
+		}
+	}
+
+	var s3WriteAvailability float64
+	if cond := meta.FindStatusCondition(backupConfig.Status.Conditions, v1beta1.ConditionTypeStorageWritable); cond != nil {
+		if cond.Status == v1.ConditionTrue {
+			s3WriteAvailability = 1
+		}
 	}
 
 	return &metrics.CollectMetricsResult{
@@ -161,7 +194,7 @@ func (m MetricsServerImplementation) Collect(
 			},
 			{
 				FqName: lastArchivedWALTimestampMetricName,
-				Value:  0, // TODO: fixme
+				Value:  lastArchivedWALTimeTS,
 			},
 			{
 				FqName: totalWALS3UsageBytesMetricName,
@@ -170,6 +203,14 @@ func (m MetricsServerImplementation) Collect(
 			{
 				FqName: totalBackupsS3UsageBytesMetricName,
 				Value:  totalBackupS3UsageBytes,
+			},
+			{
+				FqName: s3ReadAvailabilityMetricName,
+				Value:  s3ReadAvailability,
+			},
+			{
+				FqName: s3WriteAvailabilityMetricName,
+				Value:  s3WriteAvailability,
 			},
 		},
 	}, nil

--- a/internal/instance/plugin_wal.go
+++ b/internal/instance/plugin_wal.go
@@ -19,16 +19,23 @@ package instance
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/cloudnative-pg/cnpg-i/pkg/wal"
 	"github.com/go-logr/logr"
 	"github.com/spf13/viper"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	v1beta1 "github.com/wal-g/cnpg-plugin-wal-g/api/v1beta1"
 	"github.com/wal-g/cnpg-plugin-wal-g/internal/common"
 	"github.com/wal-g/cnpg-plugin-wal-g/pkg/walg"
+)
+
+var (
+	lastArchivedWALTime   *v1.Time // IMPORTANT: Do not access directly, use only thread-safe methods SetLastArchivedWALTime/GetLastArchivedWALTime
+	lastArchivedWALTimeMu sync.Mutex
 )
 
 // WALServiceImplementation is the implementation of the WAL Service
@@ -100,6 +107,9 @@ func (w WALServiceImplementation) Archive(
 			request.SourceFileName, err, string(result.Stdout()), string(result.Stderr()),
 		)
 	}
+
+	now := v1.Now()
+	SetLastArchivedWALTime(&now)
 
 	logger.Info(fmt.Sprintf("Successful run wal-g wal-push %s", request.SourceFileName))
 	return &wal.WALArchiveResult{}, nil
@@ -181,4 +191,24 @@ func (w WALServiceImplementation) SetFirstRequired(
 	_ *wal.SetFirstRequiredRequest,
 ) (*wal.SetFirstRequiredResult, error) {
 	panic("implement me")
+}
+
+// GetLastArchivedWALTime returns time of last successfully uploaded WAL thread-safely
+func GetLastArchivedWALTime() *v1.Time {
+	lastArchivedWALTimeMu.Lock()
+	defer lastArchivedWALTimeMu.Unlock()
+
+	if lastArchivedWALTime == nil {
+		return nil
+	}
+
+	return lastArchivedWALTime.DeepCopy()
+}
+
+// SetLastArchivedWALTime sets the time of last successfully uploaded WAL thread-safely
+func SetLastArchivedWALTime(time *v1.Time) {
+	lastArchivedWALTimeMu.Lock()
+	defer lastArchivedWALTimeMu.Unlock()
+
+	lastArchivedWALTime = time
 }

--- a/internal/operator/manager.go
+++ b/internal/operator/manager.go
@@ -39,8 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	// +kubebuilder:scaffold:imports
@@ -149,58 +148,11 @@ func Start(ctx context.Context) error {
 		CertDir: defaultWebhookCertDir,
 	})
 
-	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
-	// More info:
-	// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.4/pkg/metrics/server
-	// - https://book.kubebuilder.io/reference/metrics.html
-	metricsServerOptions := metricsserver.Options{
-		BindAddress:   viper.GetString("metrics-bind-address"),
-		SecureServing: viper.GetBool("metrics-secure"),
-		TLSOpts:       tlsOpts,
-	}
-
-	if viper.GetBool("metrics-secure") {
-		// FilterProvider is used to protect the metrics endpoint with authn/authz.
-		// These configurations ensure that only authorized users and service accounts
-		// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
-		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.4/pkg/metrics/filters#WithAuthenticationAndAuthorization
-		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
-	}
-
-	// If the certificate is not specified, controller-runtime will automatically
-	// generate self-signed certificates for the metrics server. While convenient for development and testing,
-	// this setup is not recommended for production.
-	//
-	// TODO(user): If you enable certManager, uncomment the following lines:
-	// - [METRICS-WITH-CERTS] at config/default/kustomization.yaml to generate and use certificates
-	// managed by cert-manager for the metrics server.
-	// - [PROMETHEUS-WITH-CERTS] at config/prometheus/kustomization.yaml for TLS certification.
-	metricsCertPath := viper.GetString("metrics-cert-path")
-	metricsCertName := viper.GetString("metrics-cert-name")
-	metricsCertKey := viper.GetString("metrics-cert-key")
-
-	if len(metricsCertPath) > 0 {
-		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
-			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)
-
-		var err error
-		metricsCertWatcher, err = certwatcher.New(
-			filepath.Join(metricsCertPath, metricsCertName),
-			filepath.Join(metricsCertPath, metricsCertKey),
-		)
-		if err != nil {
-			setupLog.Error(err, "to initialize metrics certificate watcher", "error", err)
-			os.Exit(1)
-		}
-
-		metricsServerOptions.TLSOpts = append(metricsServerOptions.TLSOpts, func(config *tls.Config) {
-			config.GetCertificate = metricsCertWatcher.GetCertificate
-		})
-	}
-
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                metricsServerOptions,
+		Scheme: scheme,
+		Metrics: server.Options{
+			BindAddress: "0", // Disabling metrics server by default
+		},
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: viper.GetString("health-probe-bind-address"),
 		LeaderElection:         viper.GetBool("leader-elect"),

--- a/internal/operator/plugin_lifecycle.go
+++ b/internal/operator/plugin_lifecycle.go
@@ -260,7 +260,7 @@ func reconcilePodSpecWithPluginSidecar(
 	// }
 
 	sidecarConfig := corev1.Container{}
-	sidecarConfig.Name = "plugin-yandex-extensions"
+	sidecarConfig.Name = "plugin-wal-g"
 	sidecarConfig.Image = viper.GetString("cnpg-i-pg-sidecar-image")
 	sidecarConfig.ImagePullPolicy = cluster.Spec.ImagePullPolicy
 	if jobRole == "full-recovery" {

--- a/internal/operator/plugin_lifecycle_test.go
+++ b/internal/operator/plugin_lifecycle_test.go
@@ -55,7 +55,7 @@ func applyJSONPatch(obj interface{}, patch []byte) error {
 		// Add a sidecar container to the pod
 		pod.Spec.InitContainers = []corev1.Container{
 			{
-				Name:  "plugin-yandex-extensions",
+				Name:  "plugin-wal-g",
 				Image: "test-sidecar-image:latest",
 				Args:  []string{"instance", "--mode", "normal"},
 			},
@@ -86,7 +86,7 @@ func applyJSONPatch(obj interface{}, patch []byte) error {
 		// Add a sidecar container to the job
 		pod.Spec.Template.Spec.InitContainers = []corev1.Container{
 			{
-				Name:  "plugin-yandex-extensions",
+				Name:  "plugin-wal-g",
 				Image: "test-sidecar-image:latest",
 				Args:  []string{"instance", "--mode", "recovery"},
 			},
@@ -145,7 +145,7 @@ var _ = Describe("LifecycleImplementation", func() {
 				Instances: 3,
 				Plugins: []cnpgv1.PluginConfiguration{
 					{
-						Name: common.PluginName,
+						Name: common.PluginNameDeprecated,
 						Parameters: map[string]string{
 							"backupConfig": "test-backup-config",
 						},
@@ -363,7 +363,7 @@ var _ = Describe("LifecycleImplementation", func() {
 			// Check that the sidecar container was added
 			Expect(patchedPod.Spec.InitContainers).To(HaveLen(1))
 			sidecar := patchedPod.Spec.InitContainers[0]
-			Expect(sidecar.Name).To(Equal("plugin-yandex-extensions"))
+			Expect(sidecar.Name).To(Equal("plugin-wal-g"))
 			Expect(sidecar.Image).To(Equal(sidecarImageString))
 			Expect(sidecar.Args).To(Equal([]string{"instance", "--mode", "normal"}))
 
@@ -460,7 +460,7 @@ var _ = Describe("LifecycleImplementation", func() {
 				{
 					Name: "test-recovery-source",
 					PluginConfiguration: &cnpgv1.PluginConfiguration{
-						Name: common.PluginName,
+						Name: common.PluginNameDeprecated,
 						Parameters: map[string]string{
 							"backupConfig": "test-backup-config",
 						},
@@ -494,7 +494,7 @@ var _ = Describe("LifecycleImplementation", func() {
 			// Check that the sidecar container was added
 			Expect(patchedJob.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 			sidecar := patchedJob.Spec.Template.Spec.InitContainers[0]
-			Expect(sidecar.Name).To(Equal("plugin-yandex-extensions"))
+			Expect(sidecar.Name).To(Equal("plugin-wal-g"))
 			Expect(sidecar.Image).To(Equal(sidecarImageString))
 			Expect(sidecar.Args).To(Equal([]string{"instance", "--mode", "recovery"}))
 
@@ -548,7 +548,7 @@ var _ = Describe("LifecycleImplementation", func() {
 			// Check that the sidecar container was added
 			Expect(podSpec.InitContainers).To(HaveLen(1))
 			sidecar := podSpec.InitContainers[0]
-			Expect(sidecar.Name).To(Equal("plugin-yandex-extensions"))
+			Expect(sidecar.Name).To(Equal("plugin-wal-g"))
 			Expect(sidecar.Image).To(Equal(sidecarImageString))
 			Expect(sidecar.Args).To(Equal([]string{"instance", "--mode", "normal"}))
 
@@ -682,7 +682,7 @@ var _ = Describe("LifecycleImplementation", func() {
 			}
 
 			sidecar := &corev1.Container{
-				Name:  "plugin-yandex-extensions",
+				Name:  "plugin-wal-g",
 				Image: sidecarImageString,
 			}
 
@@ -692,7 +692,7 @@ var _ = Describe("LifecycleImplementation", func() {
 
 			// Check that the sidecar container was added
 			Expect(podSpec.InitContainers).To(HaveLen(1))
-			Expect(podSpec.InitContainers[0].Name).To(Equal("plugin-yandex-extensions"))
+			Expect(podSpec.InitContainers[0].Name).To(Equal("plugin-wal-g"))
 
 			// Check that the volume mounts were copied from the main container
 			Expect(podSpec.InitContainers[0].VolumeMounts).To(ContainElement(corev1.VolumeMount{
@@ -721,7 +721,7 @@ var _ = Describe("LifecycleImplementation", func() {
 			}
 
 			sidecar := &corev1.Container{
-				Name:  "plugin-yandex-extensions",
+				Name:  "plugin-wal-g",
 				Image: sidecarImageString,
 			}
 
@@ -740,13 +740,13 @@ var _ = Describe("LifecycleImplementation", func() {
 				},
 				InitContainers: []corev1.Container{
 					{
-						Name: "plugin-yandex-extensions",
+						Name: "plugin-wal-g",
 					},
 				},
 			}
 
 			sidecar := &corev1.Container{
-				Name:  "plugin-yandex-extensions",
+				Name:  "plugin-wal-g",
 				Image: sidecarImageString,
 			}
 
@@ -864,7 +864,7 @@ var _ = Describe("LifecycleImplementation", func() {
 				Spec: cnpgv1.ClusterSpec{
 					Plugins: []cnpgv1.PluginConfiguration{
 						{
-							Name: common.PluginName,
+							Name: common.PluginNameDeprecated,
 							Parameters: map[string]string{
 								"sidecarRestartPolicy": "Always",
 							},
@@ -882,7 +882,7 @@ var _ = Describe("LifecycleImplementation", func() {
 				Spec: cnpgv1.ClusterSpec{
 					Plugins: []cnpgv1.PluginConfiguration{
 						{
-							Name: common.PluginName,
+							Name: common.PluginNameDeprecated,
 							Parameters: map[string]string{
 								"sidecarRestartPolicy": "unset",
 							},
@@ -919,7 +919,7 @@ var _ = Describe("LifecycleImplementation", func() {
 			}
 
 			sidecar = &corev1.Container{
-				Name:  "plugin-yandex-extensions",
+				Name:  "plugin-wal-g",
 				Image: "test-image:latest",
 			}
 


### PR DESCRIPTION
## PR Description

### Rebrand plugin from Yandex Extensions to WAL-G & Add Metrics Support

This PR introduces two major changes: a plugin identity rebrand and a new metrics collection capability.

---

### 🔄 Plugin Renaming & Backward Compatibility

- Renamed the internal [`PluginName`](cnpg-plugin-wal-g/internal/common/plugin_metadata.go:24) constant from `"cnpg-extensions.yandex.cloud"` to `"cnpg-plugin-wal-g"`
- The old name is preserved as [`PluginNameDeprecated`](cnpg-plugin-wal-g/internal/common/plugin_metadata.go:23) for backward compatibility with existing user manifests and public API references
- [`PluginMetadata.Name`](cnpg-plugin-wal-g/internal/common/plugin_metadata.go:29) continues to use the deprecated name to avoid breaking existing deployments
- Updated [`DisplayName`](cnpg-plugin-wal-g/internal/common/plugin_metadata.go:32) from `"CNPGYandexExtensions"` to `"CNPG Plugin WAL-G"`
- Renamed sidecar container from `"plugin-yandex-extensions"` to `"plugin-wal-g"` in [`plugin_lifecycle.go`](cnpg-plugin-wal-g/internal/operator/plugin_lifecycle.go:539) and all corresponding tests
- All plugin configuration lookups in controllers ([`backup_controller.go`](cnpg-plugin-wal-g/internal/controller/backup_controller.go:45), [`plugin_config.go`](cnpg-plugin-wal-g/internal/common/plugin_config.go:10)) now reference `PluginNameDeprecated` to maintain compatibility

### 📊 New: Plugin Metrics Collection

- Added a new [`plugin_metrics.go`](cnpg-plugin-wal-g/internal/instance/plugin_metrics.go) implementing the CNPG-I metrics interface with the following gauges:
  - `cnpg_plugin_wal_g_first_recoverability_point` — first point of recoverability as unix timestamp
  - `cnpg_plugin_wal_g_last_available_backup_timestamp` — last successful backup timestamp
  - `cnpg_plugin_wal_g_last_failed_backup_timestamp` — last failed backup timestamp
  - `cnpg_plugin_wal_g_last_archived_wal_timestamp` — last successfully archived WAL timestamp
  - `cnpg_plugin_wal_g_total_wal_s3_usage_bytes` — total S3 space consumed by WAL archives
  - `cnpg_plugin_wal_g_total_backups_s3_usage_bytes` — total S3 space consumed by base backups
  - `cnpg_plugin_wal_g_s3_read_availability` — remote storage read availability (0/1)
  - `cnpg_plugin_wal_g_s3_write_availability` — remote storage write availability (0/1)
- Registered `TYPE_METRICS` capability in [`plugin_identity.go`](cnpg-plugin-wal-g/internal/instance/plugin_identity.go:157)
- Registered the metrics gRPC server in [`plugin.go`](cnpg-plugin-wal-g/internal/instance/plugin.go:49)
- Added thread-safe [`GetLastArchivedWALTime()`](cnpg-plugin-wal-g/internal/instance/plugin_wal.go:195) / [`SetLastArchivedWALTime()`](cnpg-plugin-wal-g/internal/instance/plugin_wal.go:207) helpers with mutex protection in [`plugin_wal.go`](cnpg-plugin-wal-g/internal/instance/plugin_wal.go), updated on each successful WAL archive

### ⚙️ Operator & Instance Manager Changes

- **Disabled default metrics server** in both the [operator manager](cnpg-plugin-wal-g/internal/operator/manager.go:151) and [instance manager](cnpg-plugin-wal-g/internal/instance/manager.go:99) by setting `BindAddress: "0"` — metrics are now served via the CNPG-I plugin metrics interface instead
- Removed the entire metrics server configuration block from the operator manager (secure serving, TLS cert watcher, auth filters)

### 🕐 Reconciler Tuning

- Reduced finalizer retry interval from **1 minute** to **30 seconds** in both [`configmap_reconciler.go`](cnpg-plugin-wal-g/internal/controller/configmap_reconciler.go:84) and [`secret_reconciler.go`](cnpg-plugin-wal-g/internal/controller/secret_reconciler.go:101) for faster cleanup when resources are still referenced by a BackupConfig
