### PR TITLE
fix: fix failing postgres restore due to missing pg_wal symlink when restore is performed in separate WAL directory (closes #32)

### DIFF
--- a/internal/instance/plugin_restore.go
+++ b/internal/instance/plugin_restore.go
@@ -19,6 +19,8 @@ package instance
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/cloudnative-pg/cloudnative-pg/pkg/postgres"
 	restore "github.com/cloudnative-pg/cnpg-i/pkg/restore/job"
@@ -128,6 +130,29 @@ func (r RestoreJobHooksImpl) Restore(
 	if err != nil {
 		logger.Error(err, "Failed restore backup into data directory", "backupName", backupName, "pgdata", pgdata)
 		return nil, err
+	}
+
+	if separateWal, err := os.Stat("/var/lib/postgresql/wal"); err == nil && separateWal.IsDir() {
+		// Manually creating symlink to pg_wal directory in separate wal PVC, if not exists
+		if _, err := os.Stat(filepath.Join(pgdata, "pg_wal")); os.IsNotExist(err) {
+			if err = os.MkdirAll("/var/lib/postgresql/wal/pg_wal", 0700); err != nil {
+				logger.Error(err, "Failed to create pg_wal directory on separate wal storage", "backupName", backupName, "pgdata", pgdata)
+				return nil, err
+			}
+
+			if err = os.Symlink("/var/lib/postgresql/wal/pg_wal", filepath.Join(pgdata, "pg_wal")); err != nil {
+				logger.Error(err, "Failed to create symlink for pg_wal to separate wal storage", "backupName", backupName, "pgdata", pgdata)
+				return nil, err
+			}
+		}
+	} else {
+		// Manually creating pg_wal directory in pgdata if not exists (pg_wal dir may not be present in backup)
+		if _, err := os.Stat(filepath.Join(pgdata, "pg_wal")); os.IsNotExist(err) {
+			if err = os.MkdirAll(filepath.Join(pgdata, "pg_wal"), 0700); err != nil {
+				logger.Error(err, "Failed to create pg_wal directory", "backupName", backupName, "pgdata", pgdata)
+				return nil, err
+			}
+		}
 	}
 
 	logger.Info("Successful restore backup into data directory", "backupName", backupName, "pgdata", pgdata)

--- a/pkg/walg/config.go
+++ b/pkg/walg/config.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"reflect"
 	"slices"
 	"strconv"
@@ -264,8 +263,6 @@ func (c *Config) ToEnvMap() map[string]string {
 }
 
 func (c *Config) setWalgPrefetchDir() {
-	const pgWalDirectory = "pg_wal"
-
 	pgdataPath := viper.GetString("pgdata")
 	if pgdataPath == "" {
 		c.WalgPrefetchDir = ""
@@ -273,13 +270,9 @@ func (c *Config) setWalgPrefetchDir() {
 		return
 	}
 
-	pgWalPath, err := filepath.EvalSymlinks(filepath.Join(pgdataPath, pgWalDirectory))
-	if err != nil {
-		panic(fmt.Sprintf("error resolving symlinks for path %s: %v", filepath.Join(pgdataPath, pgWalDirectory), err))
+	if separateWal, err := os.Stat("/var/lib/postgresql/wal"); err == nil && separateWal.IsDir() {
+		c.WalgPrefetchDir = "/var/lib/postgresql/wal" // handle cases when WAL archives stored in separate PVC
+	} else {
+		c.WalgPrefetchDir = pgdataPath
 	}
-
-	// Using upper dir from pg_wal directory after symlink expand
-	// (to handle cases when WALs are stored in separate drive)
-	pgWalPrefetchDir := filepath.Dir(pgWalPath)
-	c.WalgPrefetchDir = pgWalPrefetchDir
 }


### PR DESCRIPTION

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fix failing postgres restore due to missing pg_wal symlink when restore is performed in separate WAL directory

Fixes #32

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
