### PR TITLE
fix: Skip storage cleanup on backup/backupconfig deletion when storage is not writable

### DIFF
--- a/internal/controller/backup_delete_controller.go
+++ b/internal/controller/backup_delete_controller.go
@@ -9,9 +9,11 @@ import (
 
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/go-logr/logr"
+	"github.com/samber/lo"
 	"github.com/wal-g/cnpg-plugin-wal-g/api/v1beta1"
 	"github.com/wal-g/cnpg-plugin-wal-g/pkg/walg"
 	"golang.org/x/sync/semaphore"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -263,13 +265,23 @@ func (b *BackupDeletionController) deleteWALGBackup(ctx context.Context, backupK
 		)
 	}
 
-	backupConfigWithSecrets, err := v1beta1.GetBackupConfigWithSecretsForBackup(ctx, b.Client, backup)
+	backupConfig, err := v1beta1.GetBackupConfigForBackup(ctx, b, backup)
 	if client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("while getting backupconfig with secrets for backup %v: %w", backupKey, err)
+		return fmt.Errorf("while getting backupconfig for backup %v: %w", backupKey, err)
 	}
-	if err != nil {
-		// If BackupConfig not found, then it's already deleted, just remove finalizer and do nothing else
+
+	writableCondition, writableCondFound := lo.Find(backupConfig.Status.Conditions, func(c metav1.Condition) bool {
+		return c.Type == v1beta1.ConditionTypeStorageWritable
+	})
+
+	if writableCondFound && writableCondition.Status == metav1.ConditionFalse {
+		logger.Info("Skipping Backup data cleanup because storage is inaccessible", "backupConfig", backupKey)
 		return removeBackupFinalizer(ctx, backup, b.Client)
+	}
+
+	backupConfigWithSecrets, err := backupConfig.PrefetchSecretsData(ctx, b)
+	if err != nil {
+		return fmt.Errorf("while prefetching backup secrets data for backup %v: %w", b, err)
 	}
 
 	// Check if deletion management is disabled for individual backups
@@ -315,9 +327,15 @@ func (b *BackupDeletionController) deleteBackupConfig(ctx context.Context, backu
 		return client.IgnoreNotFound(err)
 	}
 
+	writableCondition, writableCondFound := lo.Find(backupConfig.Status.Conditions, func(c metav1.Condition) bool {
+		return c.Type == v1beta1.ConditionTypeStorageWritable
+	})
+
 	// Check if deletion management is disabled for BackupConfig
 	if backupConfig.Spec.Retention.IgnoreForBackupConfigDeletion {
 		logger.Info("Deletion management disabled for BackupConfig, skipping storage cleanup", "backupConfig", backupConfigKey)
+	} else if writableCondFound && writableCondition.Status == metav1.ConditionFalse {
+		logger.Info("Skipping BackupConfig storage cleanup because storage is inaccessible", "backupConfig", backupConfigKey)
 	} else {
 		backupConfigWithSecrets, err := backupConfig.PrefetchSecretsData(ctx, b)
 		if err != nil {

--- a/internal/controller/backup_delete_controller.go
+++ b/internal/controller/backup_delete_controller.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -68,8 +69,9 @@ func NewBackupDeletionController(client client.Client) *BackupDeletionController
 
 // Start begins the backup deletion controller's periodic check
 func (b *BackupDeletionController) Start(ctx context.Context) error {
-	logger := logr.FromContextOrDiscard(ctx).WithName("BackupDeletionController")
+	logger := ctrl.Log.WithName("BackupDeletionController")
 	logger.Info("Starting backup deletion controller")
+	ctx = logr.NewContext(ctx, logger)
 
 	// Wait for context cancellation
 	for range ctx.Done() {
@@ -92,6 +94,12 @@ func (b *BackupDeletionController) Start(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// NeedLeaderElection returns true if the Runnable needs to be run in the leader election mode.
+// e.g. controllers need to be run in leader election mode, while webhook server doesn't.
+func (b *BackupDeletionController) NeedLeaderElection() bool {
+	return true
 }
 
 // EnqueueBackupDeletion adds a Backup to the deletion queue for its BackupConfig

--- a/internal/controller/backup_delete_controller.go
+++ b/internal/controller/backup_delete_controller.go
@@ -30,7 +30,7 @@ const (
 
 	// Timeout for resource cleanup, if exceeded - deletion process will be aborted and retried
 	// Needed to prevent stuck on deletion when incorrect BackupConfig / etc.
-	DeletionRequestTimeout time.Duration = 10 * time.Minute
+	DeletionRequestTimeout time.Duration = 5 * time.Minute
 )
 
 // DeletionRequest represents a request to delete a resource

--- a/internal/controller/backupconfig_controller.go
+++ b/internal/controller/backupconfig_controller.go
@@ -64,7 +64,6 @@ func (r *BackupConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// TODO(endevir): Check && report connection status into Status subresource
 	// TODO(endevir): Watch for secrets name change and reconcile cluster role
 
 	if !backupConfig.DeletionTimestamp.IsZero() {

--- a/internal/controller/backupconfig_status_controller.go
+++ b/internal/controller/backupconfig_status_controller.go
@@ -244,16 +244,18 @@ func (c *BackupConfigStatusController) reconcileStatusByKey(
 		"CredentialsResolved", "All referenced secrets and configmaps resolved successfully")
 
 	// Check storage readability
-	c.checkStorageReadable(ctx, backupConfig, walgClient, logger)
+	readable := c.checkStorageReadable(ctx, backupConfig, walgClient, logger)
 
 	// Check storage writability
 	c.checkStorageWritable(ctx, backupConfig, walgClient, logger)
 
-	// Check WAL integrity and reconcile WAL-related status fields via wal-g wal-show
-	c.reconcileWALStatus(ctx, backupConfig, backupConfigWithSecrets, logger)
+	if readable {
+		// Check WAL integrity and reconcile WAL-related status fields via wal-g wal-show
+		c.reconcileWALStatus(ctx, backupConfig, backupConfigWithSecrets, logger)
 
-	// Reconcile backup-related status fields from wal-g backup-list and CNPG Backup resources
-	c.reconcileBackupFields(ctx, backupConfig, backupConfigWithSecrets, logger)
+		// Reconcile backup-related status fields from wal-g backup-list and CNPG Backup resources
+		c.reconcileBackupFields(ctx, backupConfig, backupConfigWithSecrets, logger)
+	}
 
 	// Determine overall phase from conditions
 	backupConfig.Status.Phase = determinePhase(backupConfig)
@@ -267,40 +269,42 @@ func (c *BackupConfigStatusController) reconcileStatusByKey(
 	return nil
 }
 
-// checkStorageReadable checks if the storage is accessible for reading
+// checkStorageReadable checks if the storage is accessible for reading, returns check result as bool
 func (c *BackupConfigStatusController) checkStorageReadable(
 	ctx context.Context,
 	backupConfig *v1beta1.BackupConfig,
 	walgClient *walg.Client,
 	logger logr.Logger,
-) {
+) bool {
 	_, err := walgClient.StorageCheckReadable(ctx)
 	if err != nil {
 		logger.Error(err, "Storage read check failed")
 		setCondition(backupConfig, v1beta1.ConditionTypeStorageReadable, metav1.ConditionFalse,
-			"StorageReadCheckFailed", fmt.Sprintf("Storage read check failed: %v", err))
+			"StorageReadCheckFailed", err.Error())
 	} else {
 		setCondition(backupConfig, v1beta1.ConditionTypeStorageReadable, metav1.ConditionTrue,
 			"StorageReadCheckPassed", "Storage is accessible for reading")
 	}
+	return err == nil
 }
 
-// checkStorageWritable checks if the storage is accessible for writing
+// checkStorageWritable checks if the storage is accessible for writing, returns check result as bool
 func (c *BackupConfigStatusController) checkStorageWritable(
 	ctx context.Context,
 	backupConfig *v1beta1.BackupConfig,
 	walgClient *walg.Client,
 	logger logr.Logger,
-) {
+) bool {
 	_, err := walgClient.StorageCheckWritable(ctx)
 	if err != nil {
 		logger.Error(err, "Storage write check failed")
 		setCondition(backupConfig, v1beta1.ConditionTypeStorageWritable, metav1.ConditionFalse,
-			"StorageWriteCheckFailed", fmt.Sprintf("Storage write check failed: %v", err))
+			"StorageWriteCheckFailed", err.Error())
 	} else {
 		setCondition(backupConfig, v1beta1.ConditionTypeStorageWritable, metav1.ConditionTrue,
 			"StorageWriteCheckPassed", "Storage is accessible for writing")
 	}
+	return err == nil
 }
 
 // reconcileWALStatus checks WAL integrity and evaluates recoverability points

--- a/internal/controller/backupconfig_status_controller.go
+++ b/internal/controller/backupconfig_status_controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/wal-g/cnpg-plugin-wal-g/pkg/walg"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -39,7 +40,7 @@ const (
 	maxStatusReconcileConcurrency = 3
 
 	// Timeout for a single BackupConfig status reconciliation
-	statusReconcileTimeout = 3 * time.Minute
+	statusReconcileTimeout = 10 * time.Minute
 
 	// Size of the shared reconciliation request queue
 	statusReconcileQueueSize = 256
@@ -81,12 +82,13 @@ func NewBackupConfigStatusController(client client.Client, checkInterval time.Du
 
 // Start begins the status controller's periodic reconciliation loop and worker pool
 func (c *BackupConfigStatusController) Start(ctx context.Context) error {
-	c.ctx = ctx
-	c.logger = logr.FromContextOrDiscard(ctx).WithName("BackupConfigStatusController")
+	c.logger = ctrl.Log.WithName("BackupConfigStatusController")
 	c.logger.Info("Starting BackupConfig status controller",
 		"checkInterval", c.checkInterval,
 		"workers", maxStatusReconcileConcurrency,
 	)
+	ctx = logr.NewContext(ctx, c.logger)
+	c.ctx = ctx
 
 	// Start the static worker pool
 	var wg sync.WaitGroup
@@ -114,6 +116,12 @@ func (c *BackupConfigStatusController) Start(ctx context.Context) error {
 			c.enqueueAllStatuses(ctx)
 		}
 	}
+}
+
+// NeedLeaderElection returns true if the Runnable needs to be run in the leader election mode.
+// e.g. controllers need to be run in leader election mode, while webhook server doesn't.
+func (c *BackupConfigStatusController) NeedLeaderElection() bool {
+	return true
 }
 
 // EnqueueStatusUpdate enqueues a status reconciliation for a specific BackupConfig.
@@ -144,12 +152,6 @@ func (c *BackupConfigStatusController) enqueueAllStatuses(ctx context.Context) {
 
 	for i := range backupConfigList.Items {
 		backupConfig := &backupConfigList.Items[i]
-
-		// Skip BackupConfigs that are being deleted
-		if !backupConfig.DeletionTimestamp.IsZero() {
-			continue
-		}
-
 		c.EnqueueStatusUpdate(types.NamespacedName{
 			Namespace: backupConfig.Namespace,
 			Name:      backupConfig.Name,
@@ -222,28 +224,7 @@ func (c *BackupConfigStatusController) reconcileStatusByKey(
 		return client.IgnoreNotFound(err)
 	}
 
-	// Skip if being deleted
-	if !backupConfig.DeletionTimestamp.IsZero() {
-		return nil
-	}
-
-	return c.reconcileStatus(ctx, backupConfig, logger)
-}
-
-// reconcileStatus reconciles the status of a single BackupConfig
-func (c *BackupConfigStatusController) reconcileStatus(
-	ctx context.Context,
-	backupConfig *v1beta1.BackupConfig,
-	logger logr.Logger,
-) error {
 	logger.Info("Reconciling BackupConfig status")
-
-	// Re-fetch the BackupConfig to get the latest version
-	latestBackupConfig := &v1beta1.BackupConfig{}
-	if err := c.client.Get(ctx, client.ObjectKeyFromObject(backupConfig), latestBackupConfig); err != nil {
-		return fmt.Errorf("failed to get latest BackupConfig: %w", err)
-	}
-	backupConfig = latestBackupConfig
 
 	// Prefetch secrets for wal-g client
 	backupConfigWithSecrets, err := backupConfig.PrefetchSecretsData(ctx, c.client)

--- a/internal/controller/backupconfig_status_controller.go
+++ b/internal/controller/backupconfig_status_controller.go
@@ -39,10 +39,10 @@ const (
 	maxStatusReconcileConcurrency = 3
 
 	// Timeout for a single BackupConfig status reconciliation
-	statusReconcileTimeout = 10 * time.Minute
+	statusReconcileTimeout = 3 * time.Minute
 
 	// Size of the shared reconciliation request queue
-	statusReconcileQueueSize = 128
+	statusReconcileQueueSize = 256
 )
 
 // BackupConfigStatusController periodically reconciles BackupConfigStatus fields
@@ -134,6 +134,11 @@ func (c *BackupConfigStatusController) enqueueAllStatuses(ctx context.Context) {
 	backupConfigList := &v1beta1.BackupConfigList{}
 	if err := c.client.List(ctx, backupConfigList); err != nil {
 		c.logger.Error(err, "Failed to list BackupConfig resources")
+		return
+	}
+
+	if len(c.queue) > 0 {
+		c.logger.Error(fmt.Errorf("there are still some backupconfigs pending in queue"), "Cannot enqueue backupconfigs for status update")
 		return
 	}
 

--- a/internal/controller/retention_controller.go
+++ b/internal/controller/retention_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/samber/lo"
 	v1beta1 "github.com/wal-g/cnpg-plugin-wal-g/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,8 +34,9 @@ func NewRetentionController(client client.Client, checkInterval time.Duration) *
 
 // Start begins the retention controller's periodic check
 func (r *RetentionController) Start(ctx context.Context) error {
-	logger := logr.FromContextOrDiscard(ctx).WithName("RetentionController")
+	logger := ctrl.Log.WithName("RetentionController")
 	logger.Info("Starting retention controller", "checkInterval", r.checkInterval)
+	ctx = logr.NewContext(ctx, logger)
 
 	ticker := time.NewTicker(r.checkInterval)
 	defer ticker.Stop()

--- a/internal/operator/manager.go
+++ b/internal/operator/manager.go
@@ -28,6 +28,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/viper"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -105,6 +106,7 @@ func Start(ctx context.Context) error {
 	opts.BindFlags(flag.CommandLine)
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctx = logr.NewContext(ctx, ctrl.Log)
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -122,7 +124,7 @@ func Start(ctx context.Context) error {
 	}
 
 	// Create watchers for metrics and webhooks certificates
-	var metricsCertWatcher, webhookCertWatcher *certwatcher.CertWatcher
+	var webhookCertWatcher *certwatcher.CertWatcher
 
 	webhookCertPath := viper.GetString("webhook-cert-path")
 	webhookCertName := viper.GetString("webhook-cert-name")
@@ -206,7 +208,7 @@ func Start(ctx context.Context) error {
 	// Create and add the BackupConfigStatusController
 	backupConfigStatusController := controller.NewBackupConfigStatusController(
 		mgr.GetClient(),
-		5*time.Minute, // Run status reconciliation each 5 minutes
+		2*time.Minute, // Run status reconciliation each 2 minutes
 	)
 	if err := mgr.Add(backupConfigStatusController); err != nil {
 		setupLog.Error(err, "unable to add controller", "controller", "BackupConfigStatusController")
@@ -254,14 +256,6 @@ func Start(ctx context.Context) error {
 	if err = webhookv1.SetupBackupConfigWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "PostgresqlCluster")
 		os.Exit(1)
-	}
-
-	if metricsCertWatcher != nil {
-		setupLog.Info("Adding metrics certificate watcher to manager")
-		if err := mgr.Add(metricsCertWatcher); err != nil {
-			setupLog.Error(err, "unable to add metrics certificate watcher to manager")
-			return err
-		}
 	}
 
 	if webhookCertWatcher != nil {

--- a/pkg/walg/backups.go
+++ b/pkg/walg/backups.go
@@ -140,7 +140,7 @@ func (c *Client) GetBackupsList(ctx context.Context) ([]BackupMetadata, error) {
 		)
 		return nil, fmt.Errorf("failed to do wal-g backup-list: %w", err)
 	}
-	logger.Info("Finished wal-g backup-list", "stdout", string(result.Stdout()), "stderr", string(result.Stderr()))
+	logger.V(1).Info("Finished wal-g backup-list", "stdout", string(result.Stdout()), "stderr", string(result.Stderr()))
 
 	backupsMetadata := make([]BackupMetadata, 0)
 	if err = json.Unmarshal(result.Stdout(), &backupsMetadata); err != nil {

--- a/pkg/walg/storage.go
+++ b/pkg/walg/storage.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/wal-g/cnpg-plugin-wal-g/internal/util/cmd"
@@ -58,8 +59,10 @@ func (w *WALTimelineInfo) IsOK() bool {
 func (c *Client) StorageCheckReadable(ctx context.Context) (*cmd.RunResult, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
+	commandCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
 	result, err := cmd.New("wal-g", "st", "check", "read").
-		WithContext(ctx).
+		WithContext(commandCtx).
 		WithEnv(c.config.ToEnvMap()).
 		Run()
 
@@ -78,8 +81,10 @@ func (c *Client) StorageCheckReadable(ctx context.Context) (*cmd.RunResult, erro
 func (c *Client) StorageCheckWritable(ctx context.Context) (*cmd.RunResult, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
+	commandCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
 	result, err := cmd.New("wal-g", "st", "check", "write").
-		WithContext(ctx).
+		WithContext(commandCtx).
 		WithEnv(c.config.ToEnvMap()).
 		Run()
 
@@ -99,8 +104,10 @@ func (c *Client) StorageCheckWritable(ctx context.Context) (*cmd.RunResult, erro
 func (c *Client) WALShow(ctx context.Context) ([]WALTimelineInfo, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
+	commandCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
 	result, err := cmd.New("wal-g", "wal-show", "--detailed-json").
-		WithContext(ctx).
+		WithContext(commandCtx).
 		WithEnv(c.config.ToEnvMap()).
 		Run()
 
@@ -131,8 +138,10 @@ func (c *Client) WALShow(ctx context.Context) ([]WALTimelineInfo, error) {
 func (c *Client) StorageLsTotalSize(ctx context.Context, path string) (int64, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
+	commandCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
 	result, err := cmd.New("wal-g", "st", "ls", path).
-		WithContext(ctx).
+		WithContext(commandCtx).
 		WithEnv(c.config.ToEnvMap()).
 		Run()
 


### PR DESCRIPTION
## Description

Skip storage cleanup when storage is not writable. Both deleteWALGBackup and deleteBackupConfig now check the `ConditionTypeStorageWritable` status condition on the related BackupConfig:

- In deleteWALGBackup: if the storage is reported as not writable, the backup's finalizer is removed without attempting to delete any data in object storage. This prevents the controller from getting stuck trying to delete backups from an unreachable/misconfigured storage.

- In deleteBackupConfig: the storage cleanup step is skipped under the same condition, alongside the existing IgnoreForBackupConfigDeletion branch.



## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [x] Unit tests
- [x] Manual tests
