### PR TITLE
Allow deletion failed backups by retention policy when total healthy backups < MinBackupsToKeep

### DIFF
--- a/internal/controller/retention_controller.go
+++ b/internal/controller/retention_controller.go
@@ -146,7 +146,6 @@ func (r *RetentionController) getBackupsToDelete(
 	backupConfig *v1beta1.BackupConfig,
 	backupList []cnpgv1.Backup,
 ) ([]cnpgv1.Backup, error) {
-	logger := logr.FromContextOrDiscard(ctx)
 	retention := backupConfig.Spec.Retention
 
 	// If no retention policy is configured, return empty list
@@ -185,17 +184,6 @@ func (r *RetentionController) getBackupsToDelete(
 		minBackupsToKeep = retention.MinBackupsToKeep
 	}
 
-	// If we have fewer successful backups than minBackupsToKeep, keep all
-	successfulBackups := lo.Filter(backupList, func(b cnpgv1.Backup, _ int) bool {
-		return b.Status.Phase == cnpgv1.BackupPhaseCompleted && b.DeletionTimestamp == nil
-	})
-	if len(successfulBackups) <= minBackupsToKeep {
-		logger.Info("Number of successful backups is less than or equal to MinBackupsToKeep, keeping all",
-			"backupCount", len(backupList),
-			"minBackupsToKeep", minBackupsToKeep)
-		return []cnpgv1.Backup{}, nil
-	}
-
 	backupsToDelete := make([]cnpgv1.Backup, 0)
 	// Process backups from oldest to newest (they're already sorted)
 	for i := range backupList {
@@ -214,9 +202,26 @@ func shouldDeleteBackup(ctx context.Context, backupList []cnpgv1.Backup, backupI
 
 	logger := logr.FromContextOrDiscard(ctx)
 
+	if backup.DeletionTimestamp != nil {
+		// Backup is already being deleted, skipping its retention check
+		return false
+	}
+
+	if backup.Status.Phase == cnpgv1.BackupPhasePending ||
+		backup.Status.Phase == cnpgv1.BackupPhaseStarted ||
+		backup.Status.Phase == cnpgv1.BackupPhaseRunning ||
+		backup.Status.Phase == cnpgv1.BackupPhaseFinalizing {
+		logger.Info("Backup is in unfinished state, skipping its retention check", "backupName", backup.Name)
+		return false
+	}
+
 	// Skip if this is one of the newest backups we want to keep
-	remainingBackups := len(backupList) - backupIndex
-	if remainingBackups <= minBackupsToKeep {
+	backupIsHealthy := backup.Status.Phase == cnpgv1.BackupPhaseCompleted && backup.DeletionTimestamp == nil
+	remainingSuccessfulBackups := lo.CountBy(backupList[backupIndex+1:], func(b cnpgv1.Backup) bool {
+		return b.Status.Phase == cnpgv1.BackupPhaseCompleted && b.DeletionTimestamp == nil
+	})
+
+	if backupIsHealthy && remainingSuccessfulBackups < minBackupsToKeep {
 		logger.Info("Keeping backup as part of MinBackupsToKeep", "backupName", backup.Name)
 		return false
 	}

--- a/internal/controller/retention_controller_test.go
+++ b/internal/controller/retention_controller_test.go
@@ -326,8 +326,8 @@ var _ = Describe("RetentionController", func() {
 						StartTime:        time.Now().Add(-48 * time.Hour),
 					}),
 				},
-				expectedCount: 0,
-				expectedNames: []string{},
+				expectedCount: 1,
+				expectedNames: []string{"backup3-error"}, // Awaiting that errored old backups will be deleted anyway despite MinBackupsToKeep setting
 			}),
 			Entry("more backups than minBackupsToKeep with time threshold", testCase{
 				description: "more backups than minBackupsToKeep with time threshold",


### PR DESCRIPTION
## Description

Refactors backup retention logic to allow deletion of failed/errored backups even when below `MinBackupsToKeep` threshold. Previously, the controller would skip all deletions if total successful backups were at or below the minimum. Now, the check is performed per-backup, protecting only healthy backups while allowing cleanup of failed ones.

**Changes:**
- Moved `MinBackupsToKeep` check from [`getBackupsToDelete()`](cnpg-plugin-wal-g/internal/controller/retention_controller.go:146) to [`shouldDeleteBackup()`](cnpg-plugin-wal-g/internal/controller/retention_controller.go:201)
- Added safety checks to skip backups already being deleted or in unfinished states
- Updated logic to count only remaining successful backups when evaluating retention
- Removed unused logger variable

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests - Updated test expectations to verify errored backups are deleted despite `MinBackupsToKeep` setting

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes