### PR TITLE
Fix cnpg rolling updates stuck when pod lifecycle hook applies immutable fields changes

### DIFF
--- a/internal/operator/plugin_lifecycle.go
+++ b/internal/operator/plugin_lifecycle.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -126,9 +127,19 @@ func (impl LifecycleImplementation) reconcilePod(
 	if err != nil {
 		return nil, err
 	}
-
 	logger := logr.FromContextOrDiscard(ctx).WithValues("podName", pod.Name, "podNamespace", pod.Namespace)
 	logger.V(1).Info("Reconciling pod")
+
+	allowedChangeTypesToApplyPatch := []lifecycle.OperatorOperationType_Type{
+		lifecycle.OperatorOperationType_TYPE_CREATE,
+		lifecycle.OperatorOperationType_TYPE_EVALUATE,
+	}
+
+	// Perform spec changes only on "allowed" change requests
+	if !slices.Contains(allowedChangeTypesToApplyPatch, request.OperationType.Type) {
+		logger.V(1).Info("Nothing to do, because operation is not in allowed change types to be patched", "operation", request.OperationType.Type)
+		return &lifecycle.OperatorLifecycleResponse{}, nil
+	}
 
 	mutatedPod := pod.DeepCopy()
 


### PR DESCRIPTION

## Description

This PR fixes CNPG rolling update stuck when `primaryUpdateMethod: switchover` is used after update to v0.3.0-rc1. This is caused by cnpg-plugin-wal-g sidecar rename, which prevents cnpg operator to patch Pods (specifically - to update labels and perform switchover) and proceed with update.

Now Pod spec patch is returned to CNPG only on pod creation or changes evaluation requests. For other requests types (ex. PATCH or DELETE) nothing is returned by plugin

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [x] Unit tests
- [x] Manual tests
